### PR TITLE
Finalise BE refactor to fully remove code duplication when defining a new data source

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -60,13 +60,24 @@ app.add_middleware(
 
 # Generic search methods.
 
-async def elastic_search(params, filters, index_name, aggregation_fields=None):
+async def elastic_search(params, index_name, data_class, aggregation_class):
 
     # Build the query body based on whether there is full text search.
     if params.q:
         query_body = {"multi_match": {"query": params.q, "fields": ["*"]}}
     else:
         query_body = {"match_all": {}}
+
+    # Adding filters.
+    filters = []
+    aggregation_fields=get_list_of_aggregations(MaveDBAggregationResponse)
+    if aggregation_fields:
+        for aggregation_field in aggregation_fields:
+            filter_value = getattr(params, aggregation_field)
+            print(f"{aggregation_field}={filter_value}")
+            if filter_value:
+                filters.append(
+                    {"terms": {aggregation_field: [filter_value]}})
 
     # Combine query with filters.
     search_body = {"from": params.start, "size": params.size, "query": {
@@ -94,7 +105,14 @@ async def elastic_search(params, filters, index_name, aggregation_fields=None):
         total = response["hits"]["total"]["value"]
         hits = [r["_source"] for r in response["hits"]["hits"]]
         aggregations = response["aggregations"]
-        return total, hits, aggregations
+        # Return the results.
+        return ElasticResponse[data_class, aggregation_class](
+            total=total,
+            start=params.start,
+            size=params.size,
+            results=hits,
+            aggregations=aggregations,
+        )
 
     except Exception as e:
         # Handle Elasticsearch errors.
@@ -119,34 +137,12 @@ async def elastic_details(index_name, record_id):
 async def mavedb_search(
     params: Annotated[MaveDBSearchParams, Query()]
     ) -> ElasticResponse[MaveDBData, MaveDBAggregationResponse]:
-
-    # Adding filters from the filters query parameter.
-    filters = []
-    if params.publication_year:
-        filters.append(
-            {"terms": {"publicationYear": [params.publication_year]}})
-    if params.gene_category:
-        filters.append({"terms": {"geneCategory": [params.gene_category]}})
-    if params.sequence_type:
-        filters.append({"terms": {"sequenceType": [params.sequence_type]}})
-
-    # Perform the search.
-    total, hits, aggregations = await elastic_search(
+    return await elastic_search(
         params=params,
-        filters=filters,
         index_name="mavedb",
-        aggregation_fields=get_list_of_aggregations(MaveDBAggregationResponse),
+        data_class=MaveDBData,
+        aggregation_class=MaveDBAggregationResponse,
     )
-
-    # Return the results.
-    return ElasticResponse[MaveDBData, MaveDBAggregationResponse](
-        total=total,
-        start=params.start,
-        size=params.size,
-        results=hits,
-        aggregations=aggregations,
-    )
-
 
 @app.get("/mavedb/search/{record_id}")
 async def mavedb_details(

--- a/be/main.py
+++ b/be/main.py
@@ -74,7 +74,6 @@ async def elastic_search(index_name, params, data_class, aggregation_class):
     if aggregation_fields:
         for aggregation_field in aggregation_fields:
             filter_value = getattr(params, aggregation_field)
-            print(f"{aggregation_field}={filter_value}")
             if filter_value:
                 filters.append(
                     {"terms": {aggregation_field: [filter_value]}})

--- a/be/models.py
+++ b/be/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Generic, List, Literal, TypeVar
+from typing import Generic, Literal, TypeVar
 
 T = TypeVar("T")  # Datasource data type
 A = TypeVar("A")  # Datasource aggregation type
@@ -26,11 +26,11 @@ class ElasticResponse(BaseModel, Generic[T, A]):
     total: int
     start: int
     size: int
-    results: List[T]
+    results: list[T]
     aggregations: A
 
 class ElasticDetailsResponse(BaseModel, Generic[T]):
-    results: List[T]
+    results: list[T]
 
 
 # Base Elastic query class.
@@ -62,7 +62,7 @@ class DataSource:
     def __init__(
         self,
         name: str,
-        fields: List[FieldDefinition],
+        fields: list[FieldDefinition],
         default_sort_field: str,
         default_sort_order: Literal["desc", "asc"],
     ):

--- a/be/models.py
+++ b/be/models.py
@@ -19,6 +19,7 @@ class Aggregation(BaseModel):
 def get_list_of_aggregations(aggregation_class):
     return sorted(aggregation_class.schema()["properties"].keys())
 
+
 # Generic Elastic response classes.
 
 class ElasticResponse(BaseModel, Generic[T, A]):

--- a/be/models.py
+++ b/be/models.py
@@ -70,12 +70,12 @@ class MaveDBAggregationResponse(BaseModel):
 class MaveDBSearchParams(SearchParams):
     sort_field: str | None = Field("publicationYear", description="Sort field")
     sort_order: Literal["desc", "asc"] = "desc"
-    publication_year: str | None = Field(
+    publicationYear: str | None = Field(
         None, description="PublicationYear query", alias="publicationYear"
     )
-    gene_category: str | None = Field(
+    geneCategory: str | None = Field(
         None, description="GeneCategory query", alias="geneCategory"
     )
-    sequence_type: str | None = Field(
+    sequenceType: str | None = Field(
         None, description="SequenceType query", alias="sequenceType"
     )


### PR DESCRIPTION
The data source-specific classes are now dynamically generated. This means that when adding a new data source, the **entire** definition contains a single class:

```python
mavedb = DataSource(
    name="MaveDB",
    fields=[
        FieldDefinition(name="urn", type=str),
        FieldDefinition(name="title", type=str),
        FieldDefinition(name="shortDescription", type=str),
        FieldDefinition(name="sequenceType", type=str, filterable=True),
        FieldDefinition(name="geneName", type=str),
        FieldDefinition(name="geneCategory", type=str, filterable=True),
        FieldDefinition(name="publicationUrl", type=str),
        FieldDefinition(name="publicationYear", type=int, filterable=True),
        FieldDefinition(name="numVariants", type=int),
    ],
    default_sort_field="publicationYear",
    default_sort_order="desc",
)
MaveDBData, MaveDBAggregationResponse, MaveDBSearchParams = mavedb.generate_classes()
```

And two very succinct API call methods:

```python
@app.get("/mavedb/search")
async def mavedb_search(
    params: Annotated[MaveDBSearchParams, Query()]
    ) -> ElasticResponse[MaveDBData, MaveDBAggregationResponse]:
    return await elastic_search(
        index_name="mavedb",
        params=params,
        data_class=MaveDBData,
        aggregation_class=MaveDBAggregationResponse,
    )

@app.get("/mavedb/search/{record_id}")
async def mavedb_details(
    record_id: Annotated[str, Path(description="Record ID")]
    ) -> ElasticDetailsResponse[MaveDBData]:
    return await elastic_details(
        index_name="mavedb",
        record_id=record_id,
        data_class=MaveDBData,
    )
```

**All of the rest** is common logic, reused across data sources.

Closes #100.