### PR TITLE
Set up automatic Python code style enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.10

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This monorepo contains data processing, back-end, and front-end facilities for the Perturbation Catalogue project. Try it out:
 * **API** → https://perturbation-catalogue-be-959149465821.europe-west2.run.app/search
 * **Website** → https://perturbation-catalogue-fe-959149465821.europe-west2.run.app
+
+## Set up
+This repository uses the [Black formatter](https://black.readthedocs.io/en/stable/) for Python code. To set it up, use:
+
+```python
+pip install pre-commit black
+pre-commit install
+```
+
+You only need to run these commands once.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Perturbation Catalogue
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 This monorepo contains data processing, back-end, and front-end facilities for the Perturbation Catalogue project. Try it out:
 * **API** → https://perturbation-catalogue-be-959149465821.europe-west2.run.app/search
 * **Website** → https://perturbation-catalogue-fe-959149465821.europe-west2.run.app

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This monorepo contains data processing, back-end, and front-end facilities for t
 * **Website** → https://perturbation-catalogue-fe-959149465821.europe-west2.run.app
 
 ## Set up
-This repository uses the [Black formatter](https://black.readthedocs.io/en/stable/) for Python code. To set it up, use:
+To automatically enforce the code style before committing, run:
 
 ```python
 pip install pre-commit black


### PR DESCRIPTION
> [!WARNING]  
> This PR is based on top of https://github.com/EMBL-EBI-ABC/PerturbationCatalogue/pull/101 and should only be merged **after** that one is merged.

Part of work in #102. This change makes it so that the code is automatically checked and style corrected. The code style used is [**Black**](https://black.readthedocs.io/en/stable/index.html), a very popular and widely used tool across many Python projects.