### PR TITLE
Make it possible to specify text/keyword and fielddata properties at the time of Elastic index creation

### DIFF
--- a/data_sources/depmap/README.md
+++ b/data_sources/depmap/README.md
@@ -36,5 +36,32 @@ gsutil -q -m rm -r "gs://${WAREHOUSE_BUCKET}/depmap"
 gsutil cp /tmp/gene_dependency.jsonl gs://${WAREHOUSE_BUCKET}/depmap/gene_dependency.jsonl
 
 # Ingest into Elastic.
-bash ../elastic_load.sh "${ELASTIC_ENDPOINT}" "depmap" "gs://${WAREHOUSE_BUCKET}/depmap/gene_dependency.jsonl"
+bash ../elastic_load.sh \
+  "${ELASTIC_ENDPOINT}" \
+  "depmap" \
+  "gs://${WAREHOUSE_BUCKET}/depmap/gene_dependency.jsonl" \
+  '
+    "OncotreePrimaryDisease": {
+      "type": "text",
+      "fielddata": true
+    },
+    "AgeCategory": {
+      "type": "keyword"
+    },
+    "ModelType": {
+      "type": "keyword"
+    },
+    "OncotreeLineage": {
+      "type": "keyword"
+    },
+    "PrimaryOrMetastasis": {
+      "type": "keyword"
+    },
+    "SampleCollectionSite": {
+      "type": "keyword"
+    },
+    "Sex": {
+      "type": "keyword"
+    }
+  '
 ```

--- a/data_sources/elastic_load.sh
+++ b/data_sources/elastic_load.sh
@@ -4,19 +4,28 @@ set -euo pipefail
 export ELASTIC_ENDPOINT="$1"
 export ELASTIC_INDEX="$2"
 export JSONL_DATA="$3"
+export FIELD_PROPERTIES="$4"
 
 echo "Removing the index..."
 curl -X DELETE "${ELASTIC_ENDPOINT}/${ELASTIC_INDEX}" -H "Content-Type: application/json"
 
 echo -e "\nCreating the index..."
-curl -X PUT "${ELASTIC_ENDPOINT}/${ELASTIC_INDEX}" -H "Content-Type: application/json" -d'{
+curl -X PUT "${ELASTIC_ENDPOINT}/${ELASTIC_INDEX}" -H "Content-Type: application/json" -d"$(cat <<EOF
+{
   "settings": {
     "index": {
       "number_of_shards": 1,
       "number_of_replicas": 1
     }
+  },
+  "mappings": {
+    "properties": {
+      $FIELD_PROPERTIES
+    }
   }
-}'
+}
+EOF
+)"
 
 echo -e "\nPreparing the data for loading..."
 gsutil -q cp "${JSONL_DATA}" /tmp/metadata.jsonl

--- a/data_sources/mavedb/README.md
+++ b/data_sources/mavedb/README.md
@@ -35,5 +35,5 @@ gsutil -q -m rm -r "gs://${WAREHOUSE_BUCKET}/mavedb"
 gsutil -q cp /tmp/metadata.jsonl "gs://${WAREHOUSE_BUCKET}/mavedb/metadata.jsonl"
 
 # Ingest into Elastic.
-bash ../elastic_load.sh "${ELASTIC_ENDPOINT}" "mavedb" "gs://${WAREHOUSE_BUCKET}/mavedb/metadata.jsonl"
+bash ../elastic_load.sh "${ELASTIC_ENDPOINT}" "mavedb" "gs://${WAREHOUSE_BUCKET}/mavedb/metadata.jsonl" ""
 ```


### PR DESCRIPTION
> [!TIP]
> PRs are built in a chain on top of each other. Merge order: **#107** → #108 → #109.

Also update field properties for DepMap. This is required by #97. Some fields need to be explicitly specified as keywords in order to allow filtering and aggregation; and some others need to be explicitly specified as text with fielddata=True so that they can be both sortable _and_ searchable.

Closes #105.