### PR TITLE
Normalise missing values in DepMap

### DIFF
--- a/data_sources/depmap/process.py
+++ b/data_sources/depmap/process.py
@@ -77,7 +77,19 @@ def main():
     ]
     df = df[columns_to_keep]
 
-    # Step 10: Save to JSONL format
+    # Step 10: Replace null values with "Unknown"
+    # In source data, missing values are sometimes null and sometimes "Unknown". This
+    # step fixes the inconsistency.
+    na_values = {
+        # Categorical fields; in alignment with other values in the field.
+        "SampleCollectionSite": "Unavailable",
+        "PrimaryOrMetastasis": "Unavailable",
+        # This is not categorical, so better to simply keep it empty when null.
+        "CatalogNumber": "",
+    }
+    df.fillna(value=na_values, inplace=True)
+
+    # Step 11: Save to JSONL format
     df.to_json(args.output_filename, orient="records", lines=True)
 
 


### PR DESCRIPTION
Closes #106.

This is required by #97. Essentially, the missing values in fields such as `PrimaryOrMetastasis`, `CatalogNumber` and others are sometimes represented by a literal string `"Unknown"`; and sometimes they are really missing (`null`). This creates problems both for the schema and for filters and aggregations, and needs to be addressed at the data ingestion and processing stage.