### PR TITLE
Display an optional title block for the ElasticTable component

### DIFF
--- a/fe/pages/data_portal.py
+++ b/fe/pages/data_portal.py
@@ -71,6 +71,7 @@ mavedb_table = ElasticTable(
     ],
     details_button_name="View on MaveDB",
     details_button_link=lambda urn: f"https://www.mavedb.org/score-sets/{urn}/",
+    title="MaveDB",
 )
 
 dash.register_page(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -32,7 +32,6 @@ class ElasticTable:
         title=None,
     ):
         self.api_endpoint = api_endpoint
-        self.title = title
         self.columns = columns
         self.details_button_name = details_button_name
         self.details_button_link = details_button_link
@@ -160,10 +159,17 @@ class ElasticTable:
         ]
 
         title_block = []
-        if self.title:
+        if self.title is not None:
             title_block = [
                 html.H1(
-                    self.title, className="display-4 mb-4", style={"textAlign": "left"}
+                    self.title,
+                    className="display-4 mb-2",
+                    style={
+                        "textAlign": "left",
+                        "paddingLeft": "1.5rem",
+                        "paddingTop": "1.5rem",
+                        "paddingBottom": "0.5rem",
+                    },
                 )
             ]
 

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -29,11 +29,14 @@ class ElasticTable:
         columns,
         details_button_name,
         details_button_link,
+        title=None,
     ):
         self.api_endpoint = api_endpoint
+        self.title = title
         self.columns = columns
         self.details_button_name = details_button_name
         self.details_button_link = details_button_link
+        self.title = title
 
     # Table view.
 
@@ -156,8 +159,17 @@ class ElasticTable:
             if col.filterable
         ]
 
+        title_block = []
+        if self.title:
+            title_block = [
+                html.H1(
+                    self.title, className="display-4 mb-4", style={"textAlign": "left"}
+                )
+            ]
+
         return html.Div(
             [
+                *title_block,
                 dbc.Row(
                     [
                         # Filters sidebar

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -160,9 +160,7 @@ class ElasticTable:
 
         title_block = []
         if self.title is not None:
-            title_block = [
-                html.H1(self.title, className="display-4 mb-1 ps-4 pt-4 text-start")
-            ]
+            title_block = [html.H2(self.title, className="ps-4 pt-4 mb-0")]
 
         return html.Div(
             [

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -160,7 +160,7 @@ class ElasticTable:
 
         # Table title block
         title_block = []
-        if self.title is not None:
+        if self.title:
             title_block = [html.H2(self.title, className="ps-4 pt-4 mb-0")]
 
         return html.Div(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -158,6 +158,7 @@ class ElasticTable:
             if col.filterable
         ]
 
+        # Table title block
         title_block = []
         if self.title is not None:
             title_block = [html.H2(self.title, className="ps-4 pt-4 mb-0")]

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -161,16 +161,7 @@ class ElasticTable:
         title_block = []
         if self.title is not None:
             title_block = [
-                html.H1(
-                    self.title,
-                    className="display-4 mb-2",
-                    style={
-                        "textAlign": "left",
-                        "paddingLeft": "1.5rem",
-                        "paddingTop": "1.5rem",
-                        "paddingBottom": "0.5rem",
-                    },
-                )
+                html.H1(self.title, className="display-4 mb-1 ps-4 pt-4 text-start")
             ]
 
         return html.Div(


### PR DESCRIPTION
Part of the work required for #91.

Adds an optional title block to the table. Useful when several tables are displayed on the same page — required for example by the global search.

Looks like this:

![localhost_8050_data-portal](https://github.com/user-attachments/assets/33bc5c07-7e91-473c-846e-5c25164761d8)
