### PR TITLE
Create a separate set of deployments for the latest change, not just `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,14 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 This monorepo contains data processing, back-end, and front-end facilities for the Perturbation Catalogue project. Try it out:
+
+## Main branch deployment
 * **API** → https://perturbation-catalogue-be-959149465821.europe-west2.run.app/mavedb/search
 * **Website** → https://perturbation-catalogue-dash-959149465821.europe-west2.run.app
+
+## Live deployment from the latest commit (unstable)
+* **API** → https://perturbation-catalogue-be-live-959149465821.europe-west2.run.app/mavedb/search
+* **Website** → https://perturbation-catalogue-dash-live-959149465821.europe-west2.run.app
 
 ## Set up
 To automatically enforce the code style before committing, run:

--- a/be/README.md
+++ b/be/README.md
@@ -22,11 +22,11 @@ docker run -p 8000:8000 perturbation-catalogue-be
 1. Deploy container → Service → Continuously deploy from a repository (source or function).
 1. Set up cloud build.
 1. Choose this repository → Next.
-1. Build type: Dockerfile; Source location: `/be/Dockerfile` → Save.
+1. Branch: `^main$`; Build type: Dockerfile; Source location: `/be/Dockerfile` → Save.
 1. Service name: `perturbation-catalogue-be`.
 1. Choose region.
 1. Pick: Allow unauthenticated invokations.
-1. Pick: CPU is only allocated during request processing.
+1. Billing: Request-based.
 1. Container(s), volumes, networking, security → Container(s) → Variables and Secrets → fill in environment variables:
    - ES_URL
    - ES_USERNAME
@@ -41,4 +41,6 @@ Set up path trigger:
 1. Edit the perturbation-catalogue-be trigger.
 1. Click on “Show included and ignored files filters”.
 1. Set “Included files filters (glob)” to `be/**`.
-1. Clik on “Save”.
+1. Click on “Save”.
+
+Then, repeat the steps above with the branch set to `.*` and service name to `perturbation-catalogue-be-live`. This will create a deployment which will automatically deploy the latest commit, not just from the main branch.

--- a/fe/README.md
+++ b/fe/README.md
@@ -21,7 +21,7 @@ docker build -t dash-app . && docker run -p 80:80 dash-app
 1. Deploy container → Service → Continuously deploy from a repository (source or function).
 1. Set up cloud build.
 1. Choose this repository → Next.
-1. Build type: Dockerfile; Source location: `/fe/Dockerfile` → Save.
+1. Branch: `^main$`; Build type: Dockerfile; Source location: `/fe/Dockerfile` → Save.
 1. Service name: `perturbation-catalogue-dash`.
 1. Choose region.
 1. Pick: Allow unauthenticated invokations.
@@ -42,3 +42,5 @@ This ensures that the deployment is only updated when something in `fe` is modif
 1. Click on “Show included and ignored files filters”.
 1. Set “Included files filters (glob)” to `fe/**`.
 1. Click on “Save”.
+
+Then, repeat the steps above with the branch set to `.*` and service name to `perturbation-catalogue-dash-live`. This will create a deployment which will automatically deploy the latest commit, not just from the main branch.


### PR DESCRIPTION
>[!TIP]
> PR merge order: #131 → **#132** → #133 → #134

Closes #53.

In multiple instances, I found it very inconvenient that only the main branch is deployed continuously.

This is because not all quirks and glitches surface in a local setup; so it is useful to have a deployment to test _before_ a given PR is merged.

This PR adds a second _live_ deployment for both BE and FE components. It is separate from the main branch deployment and is automatically built from the last commit pushed to any branch in the repository.