### PR TITLE
Refactor `ElasticTable` store and callback structure

### DIFF
--- a/fe/pages/data_portal.py
+++ b/fe/pages/data_portal.py
@@ -347,7 +347,7 @@ def register_callbacks(app):
     depmap_table.register_callbacks(app)
 
     @callback(
-        Output("elastic-table-mavedb-search", "value"),
+        Output("elastic-table-mavedb-search", "value", allow_duplicate=True),
         Input({"type": "gene-link", "index": dash.dependencies.ALL}, "n_clicks"),
         State({"type": "gene-link", "index": dash.dependencies.ALL}, "id"),
         prevent_initial_call=True,

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -182,6 +182,8 @@ class ElasticTable:
             [
                 *title_block,
                 *description_block,
+                # Central state store
+                dcc.Store(id=f"{self.dom_prefix}-state", data=initial_state),
                 dbc.Row(
                     [
                         # Filters sidebar

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -377,8 +377,14 @@ class ElasticTable:
         # Clientside callback for text input debounce.
         app.clientside_callback(
             """
-            function(value, oldValue) {
-                if (value === oldValue) {
+            function(value, state) {
+                // Special case for initial load - check if this is the first callback execution
+                if (!window.initialLoadComplete<id>) {
+                    window.initialLoadComplete<id> = true;
+                    return value;  // Allow the value through on first load
+                }
+
+                if (value === state.search) {
                     return window.dash_clientside.no_update;
                 }
 

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -1,6 +1,7 @@
 """A reusable and configurable class for table and details views populated by the Elastic API."""
 
 from collections import namedtuple
+import math
 
 import dash
 from dash import html, dcc, Output, Input, State
@@ -35,6 +36,7 @@ class ElasticTable:
         default_page_size=20,
     ):
         # A globally unique DOM prefix, based on the ID, to distinguish this table from all other ElasticTable instances.
+        self.id = id
         self.dom_prefix = f"elastic-table-{id}"
         self.api_endpoint = api_endpoint
         self.columns = columns

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -50,8 +50,14 @@ class ElasticTable:
         """Returns columns that should be displayed in the table view."""
         return [col for col in self.columns if col.display_table]
 
-    def _fetch_data(self, q, size, page, sort_data, filter_values):
+    def _fetch_data(self, state):
         """Fetches data from the API endpoint with the given parameters."""
+        q = state.get("search", "")
+        size = state.get("size", self.default_page_size)
+        page = state["page"]
+        sort_data = state.get("sort", {})
+        filter_values = state.get("filters", [])
+
         params = {
             "q": q,
             "size": size,

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -201,18 +201,6 @@ class ElasticTable:
                                     placeholder="Search...",
                                     className="mb-3 w-100",
                                 ),
-                                # Store to track debounce state
-                                dcc.Store(
-                                    id=f"{self.dom_prefix}-search-input-value", data=""
-                                ),
-                                # Current sort direction store
-                                dcc.Store(
-                                    id=f"{self.dom_prefix}-sort-store",
-                                    data={
-                                        "field": default_sort_column.field_name,
-                                        "order": default_sort_column.default_sort,
-                                    },
-                                ),
                                 # Main table with spinner
                                 dbc.Spinner(
                                     html.Div(


### PR DESCRIPTION
Part of work in #153, this is a deep refactor of the state and callback structure for `ElasticTable`.

**Store.** Individual stores used for debounce and sorting are removed and replaced with the _centralised state store_ of the entire component.

**Callbacks.** Multiple smaller server-side callbacks are replaced with two centralised ones:
1. The first one reacts to user actions and updates the state;
2. The second one watches updates of the state and performs the data fetch & update.

These changes set up the work for serialisation and deserialisation of the state, as well as making things more streamlined and preventing circular dependencies or callback conflicts.