### PR TITLE
Prevent auto-generation of JSON schema 

### DIFF
--- a/data_exploration/unified_metadata_schema/unified_metadata_schema.py
+++ b/data_exploration/unified_metadata_schema/unified_metadata_schema.py
@@ -501,11 +501,6 @@ class Experiment(BaseModel):
 # In-memory database for testing
 pertcat_db: list[Experiment] = []
 
-# Save the schema to a file
-# schema = Experiment.model_json_schema()
-# with open("unified_metadata_schema.json", "w") as f:
-#     json.dump(schema, f, indent=4)
-
 
 # FastAPI instance
 app = FastAPI()

--- a/data_exploration/unified_metadata_schema/unified_metadata_schema.py
+++ b/data_exploration/unified_metadata_schema/unified_metadata_schema.py
@@ -502,9 +502,9 @@ class Experiment(BaseModel):
 pertcat_db: list[Experiment] = []
 
 # Save the schema to a file
-schema = Experiment.model_json_schema()
-with open("unified_metadata_schema.json", "w") as f:
-    json.dump(schema, f, indent=4)
+# schema = Experiment.model_json_schema()
+# with open("unified_metadata_schema.json", "w") as f:
+#     json.dump(schema, f, indent=4)
 
 
 # FastAPI instance


### PR DESCRIPTION
This pull request comments out code that generates and writes the JSON schema for the `Experiment` class to the `unified_metadata_schema.json` file.