### PR TITLE
Set up common Jupyter Notebook virtual environment for data exploration

### DIFF
--- a/data_exploration/README.md
+++ b/data_exploration/README.md
@@ -1,0 +1,27 @@
+# Data exploration notebooks
+
+Data exploration notebooks use the common environment. To set it up on your machine, run from this directory:
+
+```bash
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+```
+
+Install the kernel:
+```bash
+python -m ipykernel install --user --name=data_exploration_env
+```
+
+Verify that the kernel has been added:
+
+```bash
+jupyter kernelspec list | grep data_exploration_env
+```
+
+Run Jupyter notebook:
+```bash
+jupyter notebook
+```
+
+Open any notebook and change the kernel: Kernel → Change kernel → data_exploration_env.

--- a/data_exploration/requirements.txt
+++ b/data_exploration/requirements.txt
@@ -1,0 +1,5 @@
+ipykernel
+matplotlib
+numpy
+pandas
+scanpy

--- a/data_exploration/requirements.txt
+++ b/data_exploration/requirements.txt
@@ -1,5 +1,4 @@
 ipykernel
 matplotlib
-numpy
 pandas
 scanpy


### PR DESCRIPTION
When using Jupyter Notebook, it's quite cumbersome to set up and maintain a separate virtual environment (& kernel!) for every single notebook.

The vast majority of data exploration requires a very similar toolkit: Numpy/Pandas/Matploblib and things like Scanpy/Pertpy for single cell data.

Hence, it makes sense to set up and maintain the common virtual environment for all data exploration & prototyping purposes.

I've added the basic requirements and README for setting up a Jupyter kernel. This environment will be amended as necessary.