### PR TITLE
Selection of displayed columns for each table

### DIFF
--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -225,30 +225,6 @@ class ElasticTable:
         
         # Prepare displayed columns for the table component
         displayed_columns = [
-            dbc.Card(
-                dbc.CardBody(
-                    [
-                        html.H5('Displayed Columns'),
-                        dbc.Checklist(
-                            id=f"{self.dom_prefix}-displayed-columns",
-                            options=[
-                                {"label": col.display_name, "value": col.field_name}
-                                for col in self._get_table_columns()
-                            ],
-                            value=[
-                                col.field_name
-                                for col in self._get_table_columns()
-                                if col.display_table
-                            ],
-                            className="w-100 elastic-table-display-checklist",
-                            inline=True,
-                            switch=True
-                        ),
-                    ]
-                )
-            )
-        ]
-        displayed_columns = [
             dbc.Accordion(
                 dbc.AccordionItem(
                     [
@@ -268,7 +244,7 @@ class ElasticTable:
                             switch=True
                         ),
                     ],
-                    title="Column selection"
+                    title=html.H5("Select columns", className="mb-0"),
                 ),
                 start_collapsed=True
             )

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -222,6 +222,32 @@ class ElasticTable:
             )
             for i, col in enumerate([col for col in self.columns if col.filterable])
         ]
+        
+        # Prepare displayed columns for the table component
+        displayed_columns = [
+            dbc.Card(
+                dbc.CardBody(
+                    [
+                        html.H5('Displayed Columns'),
+                        dbc.Checklist(
+                            id=f"{self.dom_prefix}-displayed-columns",
+                            options=[
+                                {"label": col.display_name, "value": col.field_name}
+                                for col in self._get_table_columns()
+                            ],
+                            value=[
+                                col.field_name
+                                for col in self._get_table_columns()
+                                if col.display_table
+                            ],
+                            className="w-100 elastic-table-display-checklist",
+                            inline=True,
+                            switch=True
+                        ),
+                    ]
+                )
+            )
+        ]
 
         # Table title block
         title_block = []
@@ -259,6 +285,13 @@ class ElasticTable:
                                     value=initial_state["search"],
                                     className="mb-3 w-100",
                                 ),
+                                # Displayed columns selection
+                                dbc.Row([
+                                    dbc.Col(
+                                        displayed_columns
+                                    )
+                                ]),
+  
                                 # Main table with spinner
                                 dbc.Spinner(
                                     html.Div(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -248,6 +248,31 @@ class ElasticTable:
                 )
             )
         ]
+        displayed_columns = [
+            dbc.Accordion(
+                dbc.AccordionItem(
+                    [
+                        dbc.Checklist(
+                            id=f"{self.dom_prefix}-displayed-columns",
+                            options=[
+                                {"label": col.display_name, "value": col.field_name}
+                                for col in self._get_table_columns()
+                            ],
+                            value=[
+                                col.field_name
+                                for col in self._get_table_columns()
+                                if col.display_table
+                            ],
+                            className="w-100 elastic-table-display-checklist",
+                            inline=True,
+                            switch=True
+                        ),
+                    ],
+                    title="Column selection"
+                ),
+                start_collapsed=True
+            )
+        ]
 
         # Table title block
         title_block = []
@@ -288,10 +313,10 @@ class ElasticTable:
                                 # Displayed columns selection
                                 dbc.Row([
                                     dbc.Col(
-                                        displayed_columns
+                                        displayed_columns,
+                                        className="mb-1 w-100"
                                     )
                                 ]),
-  
                                 # Main table with spinner
                                 dbc.Spinner(
                                     html.Div(


### PR DESCRIPTION
This pull request introduces a new feature to allow users to dynamically select which columns are displayed in a table.

The filtering functionality is available regardless of the visibility of the columns.

  - Introduced a UI component using `dbc.Accordion` and `dbc.Checklist` to allow users to select visible columns.
  - Updated `_create_table` to accept a new `displayed_columns` parameter and filter columns based on user selection.
  - Updated `fetch_data_from_state` to pass the `displayed_columns` state to `_create_table`, ensuring only selected columns are rendered.
  - Added a new `displayed_columns` entry to the initial state, mapping column field names to display names.
  - Added logic to update the `displayed_columns` state when users interact with the column selection UI.
  - Modified `register_callbacks` to include the new column selection input and handle its state updates.

