### PR TITLE
Fix Dash callback error: "Cannot read properties of undefined"

### DIFF
--- a/fe/pages/data_portal.py
+++ b/fe/pages/data_portal.py
@@ -325,7 +325,7 @@ dash.register_page(
 # Perturb-Seq.
 
 perturb_seq_table = ElasticTable(
-    id="perturb-seq",
+    id="perturb_seq",
     api_endpoint=f"{api_base_url}/perturb-seq/search",
     columns=[
         Column(

--- a/fe/pages/data_portal.py
+++ b/fe/pages/data_portal.py
@@ -516,7 +516,7 @@ def register_callbacks(app):
         Output("url", "search"),
         Input("elastic-table-depmap-state", "data"),
         Input("elastic-table-mavedb-state", "data"),
-        Input("elastic-table-perturb-seq-state", "data"),
+        Input("elastic-table-perturb_seq-state", "data"),
         prevent_initial_call=False,
     )
     def update_url_with_state(depmap_data, mavedb_data, perturb_seq_data):

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -1,6 +1,7 @@
 """A reusable and configurable class for table and details views populated by the Elastic API."""
 
 from collections import namedtuple
+import re
 import math
 
 import dash
@@ -55,6 +56,11 @@ class ElasticTable:
         default_page_size=20,
     ):
         # A globally unique DOM prefix, based on the ID, to distinguish this table from all other ElasticTable instances.
+        # The prefix will be used as part of a JavaScript variable name in a client-side callback, so must conform to
+        # JavaScript variable naming conventions.
+        assert re.fullmatch(
+            r"\w+", id
+        ), "The `id` field must only contain letters, numbers and underscores."
         self.id = id
         self.dom_prefix = f"elastic-table-{id}"
         self.api_endpoint = api_endpoint


### PR DESCRIPTION
Closes #196.

The cause of the _Cannot read properties of undefined_ issue turned out to be the naming of the Perturb-Seq ElasticTable instance. Because the self.id is later used to construct a JavaScript variable name in a clientside callback, it needs to conform to JS variable naming conventions.

Changed the name and added an assertion so that this sort of issue does not reappear in the future.