### PR TITLE
Refactor UI for the search bar & column selection area

### DIFF
--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -307,10 +307,10 @@ class ElasticTable:
                                         dbc.Col(
                                             [columns_button, columns_popover],
                                             width="auto",
+                                            className="ps-1",
                                         ),
                                     ],
                                     className="mb-3",
-                                    align="center",
                                 ),
                                 # Main table with spinner
                                 dbc.Spinner(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -291,17 +291,26 @@ class ElasticTable:
                         # Main content area
                         dbc.Col(
                             [
-                                # Search field
-                                dcc.Input(
-                                    id=f"{self.dom_prefix}-search",
-                                    type="text",
-                                    placeholder="Search...",
-                                    value=initial_state["search"],
-                                    className="mb-3 w-100",
-                                ),
-                                # Displayed columns selection
                                 dbc.Row(
-                                    [dbc.Col(displayed_columns, className="mb-1 w-100")]
+                                    [
+                                        # Search field
+                                        dbc.Col(
+                                            dbc.Input(
+                                                id=f"{self.dom_prefix}-search",
+                                                type="text",
+                                                placeholder="Search...",
+                                                value=initial_state["search"],
+                                                className="w-100",
+                                            )
+                                        ),
+                                        # Column selection component
+                                        dbc.Col(
+                                            [columns_button, columns_popover],
+                                            width="auto",
+                                        ),
+                                    ],
+                                    className="mb-3",
+                                    align="center",
                                 ),
                                 # Main table with spinner
                                 dbc.Spinner(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -239,29 +239,29 @@ class ElasticTable:
         ]
 
         # Prepare displayed columns for the table component
-        displayed_columns = [
-            dbc.Accordion(
-                dbc.AccordionItem(
-                    [
-                        dbc.Checklist(
-                            id=f"{self.dom_prefix}-displayed-columns",
-                            options=[
-                                {"value": k, "label": v}
-                                for k, v in initial_state["displayed_columns"].items()
-                            ],
-                            value=[
-                                k for k in initial_state["displayed_columns"].keys()
-                            ],
-                            className="w-100 elastic-table-display-checklist",
-                            inline=True,
-                            switch=True,
-                        ),
+        columns_button = dbc.Button(
+            "Select columns",
+            id=f"{self.dom_prefix}-columns-popover-button",
+            color="secondary",
+        )
+        columns_popover = dbc.Popover(
+            dbc.PopoverBody(
+                dbc.Checklist(
+                    id=f"{self.dom_prefix}-displayed-columns",
+                    options=[
+                        {"value": k, "label": v}
+                        for k, v in initial_state["displayed_columns"].items()
                     ],
-                    title=html.H5("Select columns", className="mb-0"),
-                ),
-                start_collapsed=True,
-            )
-        ]
+                    value=[k for k in initial_state["displayed_columns"].keys()],
+                    className="w-100",
+                    inline=True,
+                    switch=True,
+                )
+            ),
+            target=f"{self.dom_prefix}-columns-popover-button",
+            trigger="legacy",
+            placement="bottom-end",
+        )
 
         # Table title block
         title_block = []

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -243,6 +243,7 @@ class ElasticTable:
             "Select columns",
             id=f"{self.dom_prefix}-columns-popover-button",
             color="secondary",
+            outline=True,
         )
         columns_popover = dbc.Popover(
             dbc.PopoverBody(

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -255,7 +255,6 @@ class ElasticTable:
                     ],
                     value=[k for k in initial_state["displayed_columns"].keys()],
                     className="w-100",
-                    inline=True,
                     switch=True,
                 )
             ),


### PR DESCRIPTION
Closes #205.

UI refactor of the search bar & column selection area:
* Replace column selection Accordion with a Button + Popover
* Make the search field a bootstrap component instead of a pure input

Before:
![image](https://github.com/user-attachments/assets/409c777a-10e2-4e6b-a738-a3c19ea073a4)

After:
![image](https://github.com/user-attachments/assets/05950e3e-75ec-4cf9-8384-d05b5d6ece83)
