### PR TITLE
Display more than just top 10 filters in aggregations

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -101,7 +101,7 @@ async def elastic_search(index_name, params, data_class, aggregation_class):
     if aggregation_fields:
         for aggregation_field in aggregation_fields:
             search_body["aggs"][aggregation_field] = {
-                "terms": {"field": aggregation_field}
+                "terms": {"field": aggregation_field, "size": 1000000}
             }
 
     # Adding sort field and sort order

--- a/fe/assets/styles.css
+++ b/fe/assets/styles.css
@@ -34,6 +34,6 @@
     display: none;  /* By default, hide the Clear button. */
 }
 
-.elastic-table-filter-checklist:has(input:checked) ~ .elastic-table-filter-clear  {
-    display: block;  /* If any options are selected, show the Clear button. */
+div:has(> .elastic-table-filter-checklist input:checked) ~ .elastic-table-filter-clear {
+    display: block;
 }

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -211,19 +211,24 @@ class ElasticTable:
                 dbc.CardBody(
                     [
                         html.H5(col.display_name),
-                        dbc.Checklist(
-                            id=f"{self.dom_prefix}-filter-{col.field_name}",
-                            options=[],
-                            value=(
-                                initial_state["filters"][i]
-                                if initial_state.get("filters")
-                                and i < len(initial_state["filters"])
-                                else []
-                            ),
-                            className="w-100 elastic-table-filter-checklist",
-                            label_style={
-                                "maxWidth": "100%",
-                            },
+                        html.Div(
+                            [
+                                dbc.Checklist(
+                                    id=f"{self.dom_prefix}-filter-{col.field_name}",
+                                    options=[],
+                                    value=(
+                                        initial_state["filters"][i]
+                                        if initial_state.get("filters")
+                                        and i < len(initial_state["filters"])
+                                        else []
+                                    ),
+                                    className="w-100 elastic-table-filter-checklist",
+                                    label_style={
+                                        "maxWidth": "100%",
+                                    },
+                                ),
+                            ],
+                            style={"maxHeight": "260px", "overflowY": "auto"},
                         ),
                         dbc.Button(
                             "Clear",

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -228,7 +228,14 @@ class ElasticTable:
                                     },
                                 ),
                             ],
-                            style={"maxHeight": "260px", "overflowY": "auto"},
+                            style={
+                                "maxHeight": "260px",
+                                "overflowY": "auto",
+                                # A combination of left padding and negative left margin is required
+                                # for the bootstrap-styled checkboxes to not be cut off by the parent div.
+                                "paddingLeft": "5px",
+                                "marginLeft": "-5px",
+                            },
                         ),
                         dbc.Button(
                             "Clear",


### PR DESCRIPTION
Closes #169. Closes #170.

Currently, BE only returns top 10 aggregation values for every given filter.

This PR makes it so that all values are returned.

Additionally, the UI will display a scrollbar when too many values are returned, so that everything fits nicely on screen.

![image](https://github.com/user-attachments/assets/8f5723bf-7bbd-4b72-a48b-f59cc2b949f0)
