### PR TITLE
Tskir ref04 return all perturb seq

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -110,7 +110,9 @@ async def elastic_search(index_name, params, data_class, aggregation_class):
     # Performing the search.
     try:
         # Execute the async search request.
-        response = await app.state.es_client.search(index=index_name, body=search_body)
+        response = await app.state.es_client.search(
+            index=index_name, body=search_body, track_total_hits=True
+        )
         # Extract total count and hits.
         total = response["hits"]["total"]["value"]
         hits = [r["_source"] for r in response["hits"]["hits"]]

--- a/data_sources/perturb-seq/README.md
+++ b/data_sources/perturb-seq/README.md
@@ -36,6 +36,15 @@ python3 ../elastic_load.py \
       "type": "keyword"
     }
   }'
+
+# Modify the maximum number of results that can be returned.
+curl -X PUT "${ELASTIC_ENDPOINT}/perturb-seq/_settings" -H 'Content-Type: application/json' -d'
+{
+  "index": {
+    "max_result_window": 1000000
+  }
+}
+'
 ```
 
 ## Stats for the four files


### PR DESCRIPTION
Closes https://github.com/EMBL-EBI-ABC/PerturbationCatalogue/issues/197.

By raising the limits of returned hits and setting `track_total_hits` to True, we currently circumvent the issue of displaying an incorrect number of total hits for Perturb-Seq.

In the long run, after the beta release, we should migrate away from Elastic for large data queries altogether.

Before:
![image](https://github.com/user-attachments/assets/8b567254-7333-4a55-9929-3613758b4bcc)

After:
![image](https://github.com/user-attachments/assets/5db5c57b-02e5-4c5e-baae-08129edaaab0)