### PR TITLE
Fix popover element triggering page reflow/blinking

### DIFF
--- a/fe/assets/styles.css
+++ b/fe/assets/styles.css
@@ -37,3 +37,11 @@
 div:has(> .elastic-table-filter-checklist input:checked) ~ .elastic-table-filter-clear {
     display: block;
 }
+
+/*
+  Fix for the dbc.Popover reflow/blink issue. This ensures that the element is initialised
+  with absolute position from the start, to avoid triggering grid reflow.
+*/
+.popover {
+    position: absolute;
+}


### PR DESCRIPTION
Closes #200.

This fixes an issue with a popover element briefly triggering a page reflow on clicking. This is a bug in either Dash or Bootstrap implementation (probably the latter). For now, this is fixed for all popovers by setting their initialisation style to be `position: absolute`. This prevents them from being briefly displayed as a block element even briefly as component is being initialised.