### PR TITLE
Implement APIs which return the set of genes for a given datasource

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -234,6 +234,22 @@ async def depmap_details(
     )
 
 
+@app.get("/depmap/genes", response_model=list[str])
+async def depmap_genes():
+    """Returns the complete set of all genes which have any information for DepMap."""
+    aggs = {
+        "nested_genes": {
+            "nested": {"path": "high_dependency_genes"},
+            "aggs": {
+                "gene_names": {
+                    "terms": {"field": "high_dependency_genes.name", "size": 1000000}
+                }
+            },
+        }
+    }
+    return await get_unique_terms(index_name="depmap", aggs_body=aggs)
+
+
 # Perturb-Seq.
 
 

--- a/be/main.py
+++ b/be/main.py
@@ -201,6 +201,13 @@ async def mavedb_details(
     )
 
 
+@app.get("/mavedb/genes", response_model=list[str])
+async def mavedb_genes():
+    """Returns the complete set of all genes which have any information for MaveDB."""
+    aggs = {"genes": {"terms": {"field": "normalisedGeneName", "size": 1000000}}}
+    return await get_unique_terms(index_name="mavedb", aggs_body=aggs)
+
+
 # DepMap.
 
 

--- a/be/main.py
+++ b/be/main.py
@@ -274,3 +274,13 @@ async def perturb_seq_details(
         record_id=record_id,
         data_class=PerturbSeqData,
     )
+
+
+@app.get("/perturb-seq/genes", response_model=list[str])
+async def perturb_seq_genes():
+    """Returns the complete set of all genes which have any information for Perturb-Seq."""
+    aggs = {
+        "perturbations": {"terms": {"field": "perturbation", "size": 1000000}},
+        "genes": {"terms": {"field": "gene", "size": 1000000}},
+    }
+    return await get_unique_terms(index_name="perturb-seq", aggs_body=aggs)

--- a/data_sources/depmap/README.md
+++ b/data_sources/depmap/README.md
@@ -65,6 +65,9 @@ python3 ../elastic_load.py \
     },
     "xref": {
       "type": "keyword"
+    },
+    "high_dependency_genes.name": {
+      "type": "keyword"
     }
   }'
 ```

--- a/data_sources/depmap/README.md
+++ b/data_sources/depmap/README.md
@@ -66,8 +66,13 @@ python3 ../elastic_load.py \
     "xref": {
       "type": "keyword"
     },
-    "high_dependency_genes.name": {
-      "type": "keyword"
+    "high_dependency_genes": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        }
+      }
     }
   }'
 ```

--- a/data_sources/mavedb/README.md
+++ b/data_sources/mavedb/README.md
@@ -46,6 +46,9 @@ python3 ../elastic_load.py \
     },
     "sequenceType": {
       "type": "keyword"
+    },
+    "normalisedGeneName": {
+      "type": "keyword"
     }
   }'
 ```


### PR DESCRIPTION
Closes #201.

This PR implements a set of `/genes` APIs for each of the datasources, which returns a set of genes for which information is available in a given datasource.

This is intended to replace the inflexible pre-computed cross-links we used to use before.