### PR TITLE
Open a new tab instead of a scrolling callback for cross-references

### DIFF
--- a/fe/pages/data_portal.py
+++ b/fe/pages/data_portal.py
@@ -459,21 +459,6 @@ def register_callbacks(app):
     depmap_table.register_callbacks(app)
     perturb_seq_table.register_callbacks(app)
 
-    # Simple clientside callback for scrolling
-    app.clientside_callback(
-        """
-        function(value) {
-            if (value) {
-                document.getElementById('elastic-table-mavedb-search').scrollIntoView({behavior: 'smooth'});
-            }
-            return null;
-        }
-        """,
-        Output("elastic-table-mavedb-search", "_", allow_duplicate=True),
-        Input("elastic-table-mavedb-search", "value"),
-        prevent_initial_call=True,
-    )
-
     @callback(
         [
             Output({"type": "other-genes-list", "index": MATCH}, "style"),


### PR DESCRIPTION
Closes https://github.com/EMBL-EBI-ABC/PerturbationCatalogue/issues/202.

This PR ditches the custom modify-text-field-and-scroll callback and replaces it with simply opening a new tab with a prepared view.