### PR TITLE
Hide filters and pagination controls if no values are available for selection

### DIFF
--- a/fe/assets/styles.css
+++ b/fe/assets/styles.css
@@ -38,6 +38,10 @@ div:has(> .elastic-table-filter-checklist input:checked) ~ .elastic-table-filter
     display: block;
 }
 
+div.card:has(.elastic-table-filter-checklist:empty) {
+    display: none;  /* If a particular filter has no available values, hide it entirely. */
+}
+
 /*
   Fix for the dbc.Popover reflow/blink issue. This ensures that the element is initialised
   with absolute position from the start, to avoid triggering grid reflow.

--- a/fe/assets/styles.css
+++ b/fe/assets/styles.css
@@ -42,6 +42,10 @@ div.card:has(.elastic-table-filter-checklist:empty) {
     display: none;  /* If a particular filter has no available values, hide it entirely. */
 }
 
+div:has(> .elastic-table-data .no-data-message) + .elastic-table-pagination-controls {
+    display: none;  /* If no data is found, hide pagination controls. */
+}
+
 /*
   Fix for the dbc.Popover reflow/blink issue. This ensures that the element is initialised
   with absolute position from the start, to avoid triggering grid reflow.

--- a/fe/pages/elastic_table.py
+++ b/fe/pages/elastic_table.py
@@ -140,7 +140,7 @@ class ElasticTable:
     def _create_table(self, data, sort_data, displayed_columns):
         """Creates a Dash Bootstrap table from the provided data."""
         if not data:
-            return html.Div("No data found.")
+            return html.Div("No data found", className="no-data-message")
 
         return dbc.Table(
             [
@@ -340,7 +340,7 @@ class ElasticTable:
                                 dbc.Spinner(
                                     html.Div(
                                         id=f"{self.dom_prefix}-data-table",
-                                        className="w-100 overflow-auto",
+                                        className="elastic-table-data w-100 overflow-auto",
                                         style={"minHeight": "100px"},
                                     ),
                                     color="primary",
@@ -386,7 +386,7 @@ class ElasticTable:
                                             width="auto",
                                         ),
                                     ],
-                                    className="justify-content-end g-0 mt-0",
+                                    className="elastic-table-pagination-controls justify-content-end g-0 mt-0",
                                 ),
                             ],
                             className="pt-4 pe-4 ps-3",


### PR DESCRIPTION
Closes #218.

Filters / pagination are hidden with CSS, which ensures very little overhead & succinct code.