### PR TITLE
Refactor gene APIs using `after` pagination

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -399,8 +399,10 @@ async def perturb_seq_details(
 @app.get("/perturb-seq/genes", response_model=list[str])
 async def perturb_seq_genes():
     """Returns the complete set of all genes which have any information for Perturb-Seq."""
-    aggs = {
-        "perturbations": {"terms": {"field": "perturbation", "size": 1000000}},
-        "genes": {"terms": {"field": "gene", "size": 1000000}},
-    }
-    return await get_unique_terms(index_name="perturb-seq", aggs_body=aggs)
+    perturbation_task = get_all_unique_terms_paginated(
+        index_name="perturb-seq", field="perturbation"
+    )
+    gene_task = get_all_unique_terms_paginated(index_name="perturb-seq", field="gene")
+    perturbation_terms, gene_terms = await asyncio.gather(perturbation_task, gene_task)
+    all_terms = perturbation_terms.union(gene_terms)
+    return sorted(list(all_terms))

--- a/be/main.py
+++ b/be/main.py
@@ -362,17 +362,12 @@ async def depmap_details(
 @app.get("/depmap/genes", response_model=list[str])
 async def depmap_genes():
     """Returns the complete set of all genes which have any information for DepMap."""
-    aggs = {
-        "nested_genes": {
-            "nested": {"path": "high_dependency_genes"},
-            "aggs": {
-                "gene_names": {
-                    "terms": {"field": "high_dependency_genes.name", "size": 1000000}
-                }
-            },
-        }
-    }
-    return await get_unique_terms(index_name="depmap", aggs_body=aggs)
+    terms = await get_all_unique_terms_paginated(
+        index_name="depmap",
+        field="high_dependency_genes.name",
+        nested_path="high_dependency_genes",
+    )
+    return sorted(list(terms))
 
 
 # Perturb-Seq.

--- a/be/main.py
+++ b/be/main.py
@@ -325,8 +325,10 @@ async def mavedb_details(
 @app.get("/mavedb/genes", response_model=list[str])
 async def mavedb_genes():
     """Returns the complete set of all genes which have any information for MaveDB."""
-    aggs = {"genes": {"terms": {"field": "normalisedGeneName", "size": 1000000}}}
-    return await get_unique_terms(index_name="mavedb", aggs_body=aggs)
+    terms = await get_all_unique_terms_paginated(
+        index_name="mavedb", field="normalisedGeneName"
+    )
+    return sorted(list(terms))
 
 
 # DepMap.


### PR DESCRIPTION
Instead of requesting all ("1000000") genes in a single aggregation request, the request is now paginated. This will ensure it doesn't crash an Elastic instance even if/when a data core grows large enough for it to be a problem.