### PR TITLE
Fix dwh/dbt dependency issues

### DIFF
--- a/dwh/requirements.txt
+++ b/dwh/requirements.txt
@@ -1,4 +1,5 @@
 apache-beam
-dbt-bigquery
+dbt-bigquery==1.9.2
+dbt-core==1.9.2
 shandy-sqlfmt[jinjafmt]
 elasticsearch


### PR DESCRIPTION
As `requirements.txt` currently stands, when they are installed, `dbt init` fails with the following import error

```
Traceback (most recent call last):
  File "/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/bin/dbt", line 5, in <module>
    from dbt.cli.main import cli
  File "/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/lib/python3.12/site-packages/dbt/cli/__init__.py", line 1, in <module>
    from .main import cli as dbt_cli  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/lib/python3.12/site-packages/dbt/cli/main.py", line 14, in <module>
    from dbt.cli import params as p
  File "/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/lib/python3.12/site-packages/dbt/cli/params.py", line 13, in <module>
    from dbt.cli.options import MultiOption
  File "/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/lib/python3.12/site-packages/dbt/cli/options.py", line 6, in <module>
    from click.parser import _OptionParser, _ParsingState
ImportError: cannot import name '_OptionParser' from 'click.parser' (/home/ktsukanov/repositories/PerturbationCatalogue/dwh/.venv/lib/python3.12/site-packages/click/parser.py). Did you mean: 'OptionParser'?
```

Looks like the cause is recent incompatible updates to dbt/click libraries.

For now, I'm holding `dbt-bigquery` and `dbt-core` to the latest stable 1.9.* version (1.9.2) so that we can have a working environment.