### PR TITLE
Fix a bug with double sided range filtering

### DIFF
--- a/be/data_query.py
+++ b/be/data_query.py
@@ -491,9 +491,9 @@ async def _search_modality_impl(
             elif isinstance(value, str):
                 condition, params = parse_numeric_filter(db_field, value)
                 # This is a bit tricky because parse_numeric_filter doesn't know the param index
-                condition = condition.replace("$...", f"${len(pg_params) + 1}")
+                condition = condition.replace("$...", f"${len(pg_params) + 1}", 1)
                 if " AND " in condition:
-                    condition = condition.replace("$...", f"${len(pg_params) + 2}")
+                    condition = condition.replace("$...", f"${len(pg_params) + 2}", 1)
                 pg_filters.append(condition)
                 pg_params.extend(params)
 
@@ -693,9 +693,9 @@ async def _search_dataset_impl(
                 pg_params.append(value)
             elif isinstance(value, str):
                 condition, params = parse_numeric_filter(db_field, value)
-                condition = condition.replace("$...", f"${len(pg_params) + 1}")
+                condition = condition.replace("$...", f"${len(pg_params) + 1}", 1)
                 if " AND " in condition:
-                    condition = condition.replace("$...", f"${len(pg_params) + 2}")
+                    condition = condition.replace("$...", f"${len(pg_params) + 2}", 1)
                 pg_filters.append(condition)
                 pg_params.extend(params)
 


### PR DESCRIPTION
A SQL template formatting bug caused problems in some queries with double sided range, for example `/v1/mave/search?perturbation_gene_name=UBE2I&perturbation_position=35_37` to return all perturbations between positions 35 and 37 (inclusive).

All templates were replaced instead of just the first one.

This has been addressed now.