### PR TITLE
Exclude null rows which appear when no data is present in Postgres for a dataset

### DIFF
--- a/be/data_query.py
+++ b/be/data_query.py
@@ -480,6 +480,16 @@ async def _search_modality_impl(
 
     # 1. Pre-filter Datasets (Postgres)
     pg_filters = []
+
+    # Exclude "null" rows
+    essential_columns = {
+        "perturb-seq": "gene",
+        "crispr-screen": "score_name",
+        "mave": "score_name",
+    }
+    if modality in essential_columns:
+        pg_filters.append(f"{essential_columns[modality]} IS NOT NULL")
+
     pg_params: List[Any] = []
 
     for key, value in query_params.items():
@@ -698,6 +708,16 @@ async def _search_dataset_impl(
 
     # Build filters
     pg_filters = [f"dataset_id = ${1}"]
+
+    # Exclude "null" rows
+    essential_columns = {
+        "perturb-seq": "gene",
+        "crispr-screen": "score_name",
+        "mave": "score_name",
+    }
+    if modality in essential_columns:
+        pg_filters.append(f"{essential_columns[modality]} IS NOT NULL")
+
     pg_params: List[Any] = [dataset_id]
 
     for key, value in query_params.items():


### PR DESCRIPTION
*Note:* based on top of #295 and should only be merged after it.

This resolves a issue which manifests like this when metadata is present but data is not yet loaded into Postgres

<img width="1456" height="1019" alt="534817488-25dccd31-38c8-447f-b43a-73ff0d8f8971" src="https://github.com/user-attachments/assets/2c63facb-5f77-4049-801c-3ce6f345c8a5" />

