### PR TITLE
Add browsable Targets and Datasets pages with server-side pagination

### DIFF
--- a/fe/app.py
+++ b/fe/app.py
@@ -19,7 +19,7 @@ app = dash.Dash(
 )
 
 # Import pages to ensure they are registered
-from pages import api, about, dataset
+from pages import api, about, dataset, targets, datasets
 
 cookie_banner.register_callbacks(app)
 
@@ -49,6 +49,16 @@ app.layout = html.Div(
                     ),
                     html.Nav(
                         [
+                            html.A(
+                                "Targets",
+                                href="/perturbation-catalogue/targets",
+                                className="header-link",
+                            ),
+                            html.A(
+                                "Datasets",
+                                href="/perturbation-catalogue/datasets",
+                                className="header-link",
+                            ),
                             html.A(
                                 "API Documentation",
                                 href=os.getenv(

--- a/fe/components/search_table.py
+++ b/fe/components/search_table.py
@@ -1,0 +1,701 @@
+"""Shared search table components extracted from home.py."""
+
+import dash
+from dash import dcc, html
+import dash_bootstrap_components as dbc
+from urllib.parse import quote
+from utils import (
+    COLORS,
+    DATA_MODALITIES_COLOURS,
+    FACET_FIELDS,
+    results_store,
+    format_value,
+)
+
+SEARCH_RESULTS_PAGE_SIZE = 15
+
+# Mapping from canonical (target) field names to dataset index field names.
+# Used for client-side filtering of dataset results.
+TARGET_TO_DATASET_FIELD = {
+    "license": "license_labels",
+    "data_modalities": "data_modalities",
+    "tissues_tested": "tissue_labels",
+    "cell_types_tested": "cell_type_labels",
+    "cell_lines_tested": "cell_line_labels",
+    "sex_tested": "sex_labels",
+    "developmental_stages_tested": "developmental_stage_labels",
+    "diseases_tested": "disease_labels",
+}
+
+
+def format_count(value):
+    """Format numeric counts for display, falling back to '0' when missing."""
+    if value in (None, "", "N/A"):
+        return "0"
+    if isinstance(value, (int, float)):
+        return f"{int(value):,}" if isinstance(value, int) else format_value(value)
+    return format_value(value)
+
+
+def render_targets_table(results):
+    """Render the search results table for target entries."""
+    results_store.clear()
+
+    if not results:
+        return dbc.Alert(
+            [
+                html.I(className="bi bi-info-circle me-2"),
+                "No results found. Try another target name.",
+            ],
+            color="info",
+            className="shadow-sm",
+            style={"borderRadius": "10px"},
+        )
+
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th(
+                    [
+                        "Target name ",
+                        html.Span(
+                            html.I(className="bi bi-question-circle"),
+                            id="target-info-icon",
+                            style={"cursor": "pointer", "color": "#6c757d"},
+                        ),
+                        dbc.Popover(
+                            [
+                                dbc.PopoverHeader("Target Gene Aggregation"),
+                                dbc.PopoverBody(
+                                    "Results are aggregated by target gene name. Each row represents all datasets and modalities available for a specific target, combining data from Perturb-seq, CRISPR screens, and MAVE experiments across different tissues, cell types, and experimental conditions."
+                                ),
+                            ],
+                            target="target-info-icon",
+                            trigger="click",
+                            placement="bottom",
+                        ),
+                    ],
+                    className="fw-semibold",
+                ),
+                html.Th("Perturb-seq datasets", className="fw-semibold text-center"),
+                html.Th(
+                    "CRISPR-screen datasets",
+                    className="fw-semibold text-center",
+                ),
+                html.Th(
+                    "MAVE datasets",
+                    className="fw-semibold text-center",
+                ),
+                html.Th(
+                    [
+                        "Top GSEA Terms ",
+                        html.Span(
+                            html.I(className="bi bi-question-circle"),
+                            id="gsea-info-icon",
+                            style={"cursor": "pointer", "color": "#6c757d"},
+                        ),
+                        dbc.Popover(
+                            [
+                                dbc.PopoverHeader("Pathway enrichment (GSEA)"),
+                                dbc.PopoverBody(
+                                    "Shows biological pathways whose genes are collectively up- or down-regulated after a genetic perturbation, based on single-cell Perturb-seq data and MSigDB Hallmark gene sets."
+                                ),
+                            ],
+                            target="gsea-info-icon",
+                            trigger="click",
+                            placement="bottom",
+                        ),
+                    ],
+                    className="fw-semibold",
+                ),
+                html.Th("Data Modalities", className="fw-semibold"),
+            ],
+            style={"backgroundColor": "#f1f3f5"},
+        )
+    )
+
+    rows = []
+    for record in results:
+        symbol = record.get("perturbed_target_symbol", "N/A")
+        results_store[symbol] = record
+
+        n_sc_perturb_seq = format_count(record.get("n_perturb_seq"))
+        n_sc_perturb_seq_up = format_count(record.get("n_sig_perturb_pairs_up"))
+        n_sc_perturb_seq_down = format_count(record.get("n_sig_perturb_pairs_down"))
+        n_crispr = format_count(record.get("n_crispr"))
+        n_sig_crispr = format_count(record.get("n_sig_crispr"))
+        n_mave = format_count(record.get("n_mave"))
+        top_gsea_terms = record.get("top_gsea_terms") or []
+        data_modalities = record.get("data_modalities") or []
+
+        gsea_badges = []
+        for term in top_gsea_terms[:5]:
+            display_term = term if len(term) <= 25 else term[:22] + "..."
+            gsea_badges.append(
+                html.Span(
+                    dbc.Badge(
+                        display_term,
+                        color="light",
+                        className="me-1 mb-1",
+                        style={
+                            "fontSize": "0.65rem",
+                            "border": "1px solid #6c757d",
+                            "color": "#495057",
+                            "backgroundColor": "#f8f9fa",
+                            "whiteSpace": "nowrap",
+                            "overflow": "hidden",
+                            "textOverflow": "ellipsis",
+                            "maxWidth": "150px",
+                            "display": "inline-block",
+                        },
+                    ),
+                    title=term,
+                )
+            )
+        if not gsea_badges:
+            gsea_badges = [
+                html.Span(
+                    "No significant hits were found",
+                    className="text-muted",
+                    style={"fontSize": "0.8rem"},
+                )
+            ]
+
+        modalities_badges = []
+        for modality in data_modalities:
+            badge_color = DATA_MODALITIES_COLOURS.get(modality, COLORS["primary"])
+            modalities_badges.append(
+                dbc.Badge(
+                    modality,
+                    color="light",
+                    className="me-1 mb-1",
+                    style={
+                        "fontSize": "0.75rem",
+                        "border": f"1px solid {badge_color}",
+                        "color": badge_color,
+                        "backgroundColor": f"{badge_color}1A",
+                    },
+                )
+            )
+        if not modalities_badges:
+            modalities_badges = [html.Span("N/A", className="text-muted")]
+
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(
+                        dcc.Link(
+                            symbol,
+                            href=f"/perturbation-catalogue/target/{quote(symbol, safe='')}",
+                            className="text-decoration-none fw-semibold",
+                            style={"color": COLORS["primary"]},
+                        )
+                    ),
+                    html.Td(
+                        [
+                            html.Div(
+                                [
+                                    html.Span(
+                                        f"Datasets: {n_sc_perturb_seq} ",
+                                        style={
+                                            "marginRight": "5px",
+                                        },
+                                    ),
+                                    html.Span(
+                                        [
+                                            html.Span("("),
+                                            html.Span(
+                                                "Sig. genes up \u2191: ",
+                                                style={
+                                                    "color": "#1f9d55",
+                                                    "marginRight": "0.25rem",
+                                                    "fontWeight": "600",
+                                                },
+                                            ),
+                                            html.Span(
+                                                n_sc_perturb_seq_up,
+                                                style={
+                                                    "color": "#1f9d55",
+                                                    "fontWeight": "600",
+                                                },
+                                            ),
+                                            html.Span(";"),
+                                        ],
+                                        className="d-inline-flex align-items-center me-3",
+                                    ),
+                                    html.Span(
+                                        [
+                                            html.Span(
+                                                "Sig. genes down \u2193: ",
+                                                style={
+                                                    "color": "#c53030",
+                                                    "marginRight": "0.25rem",
+                                                    "fontWeight": "600",
+                                                },
+                                            ),
+                                            html.Span(
+                                                n_sc_perturb_seq_down,
+                                                style={
+                                                    "color": "#c53030",
+                                                    "fontWeight": "600",
+                                                },
+                                            ),
+                                            html.Span(")"),
+                                        ],
+                                        className="d-inline-flex align-items-center",
+                                    ),
+                                ],
+                                className="d-flex justify-content-center flex-wrap",
+                            )
+                        ],
+                        className="text-center",
+                    ),
+                    html.Td(
+                        html.Div(
+                            [
+                                html.Span(
+                                    f"Datasets: {n_crispr}",
+                                    style={
+                                        "marginRight": "5px",
+                                    },
+                                ),
+                                html.Span(
+                                    f"Sig. hits: {n_sig_crispr}",
+                                    style={
+                                        "color": "#1f9d55",
+                                        "marginRight": "0.25rem",
+                                        "fontWeight": "600",
+                                    },
+                                ),
+                            ],
+                            className="d-flex justify-content-center flex-wrap",
+                        ),
+                        className="text-center",
+                    ),
+                    html.Td(n_mave, className="text-center"),
+                    html.Td(
+                        html.Div(gsea_badges, className="d-flex flex-wrap"),
+                        style={
+                            "maxWidth": "180px",
+                            "minWidth": "120px",
+                            "overflow": "hidden",
+                        },
+                    ),
+                    html.Td(modalities_badges),
+                ]
+            )
+        )
+
+    table = dbc.Table(
+        [header, html.Tbody(rows)],
+        bordered=False,
+        hover=True,
+        responsive=True,
+        striped=False,
+        className="align-middle shadow-sm",
+        style={"borderRadius": "12px", "overflow": "hidden"},
+    )
+
+    return table
+
+
+def render_datasets_table(results):
+    """Render the search results table for dataset search results."""
+    if not results:
+        return dbc.Alert(
+            [
+                html.I(className="bi bi-info-circle me-2"),
+                "No datasets found. Try another search term.",
+            ],
+            color="info",
+            className="shadow-sm",
+            style={"borderRadius": "10px"},
+        )
+
+    header = html.Thead(
+        html.Tr(
+            [
+                html.Th("Dataset ID", className="fw-semibold"),
+                html.Th("Study Title", className="fw-semibold"),
+                html.Th("Study Year", className="fw-semibold text-center"),
+                html.Th("Data Modality", className="fw-semibold"),
+            ],
+            style={"backgroundColor": "#f1f3f5"},
+        )
+    )
+
+    rows = []
+    for record in results:
+        dataset_id = record.get("dataset_id", "N/A")
+        study_title = (
+            record.get("study_title") or record.get("experiment_title") or "N/A"
+        )
+        display_title = (
+            study_title if len(study_title) <= 60 else study_title[:57] + "..."
+        )
+        modality = record.get("data_modalities") or []
+        year = record.get("study_year") or "N/A"
+
+        modality_badges = []
+        for mod in modality:
+            badge_color = DATA_MODALITIES_COLOURS.get(mod, COLORS["primary"])
+            modality_badges.append(
+                dbc.Badge(
+                    mod,
+                    color="light",
+                    className="me-1 mb-1",
+                    style={
+                        "fontSize": "0.75rem",
+                        "border": f"1px solid {badge_color}",
+                        "color": badge_color,
+                        "backgroundColor": f"{badge_color}1A",
+                    },
+                )
+            )
+        if not modality_badges:
+            modality_badges = [html.Span("N/A", className="text-muted")]
+
+        rows.append(
+            html.Tr(
+                [
+                    html.Td(
+                        dcc.Link(
+                            dataset_id,
+                            href=f"/perturbation-catalogue/dataset/{dataset_id}",
+                            className="text-decoration-none fw-semibold",
+                            style={"color": COLORS["primary"]},
+                        )
+                    ),
+                    html.Td(
+                        html.Span(display_title, title=study_title),
+                        style={"maxWidth": "300px"},
+                    ),
+                    html.Td(str(year), className="text-center"),
+                    html.Td(html.Div(modality_badges, className="d-flex flex-wrap")),
+                ]
+            )
+        )
+
+    table = dbc.Table(
+        [header, html.Tbody(rows)],
+        bordered=False,
+        hover=True,
+        responsive=True,
+        striped=False,
+        className="align-middle shadow-sm",
+        style={"borderRadius": "12px", "overflow": "hidden"},
+    )
+
+    return table
+
+
+def recalculate_facets(filtered_results, original_facets, search_mode="targets"):
+    """Recalculate facet counts based on currently filtered results."""
+    is_dataset_mode = search_mode == "datasets"
+    recalculated = {}
+    for field in FACET_FIELDS:
+        value_counts = {}
+        result_field = (
+            TARGET_TO_DATASET_FIELD.get(field, field) if is_dataset_mode else field
+        )
+        for result in filtered_results:
+            field_value = result.get(result_field)
+            if field_value is None:
+                continue
+            if isinstance(field_value, list):
+                for v in field_value:
+                    v_str = str(v).strip()
+                    if v_str:
+                        value_counts[v_str] = value_counts.get(v_str, 0) + 1
+            else:
+                v_str = str(field_value).strip()
+                if v_str:
+                    value_counts[v_str] = value_counts.get(v_str, 0) + 1
+
+        original_values = original_facets.get(field, [])
+        facet_list = []
+        seen = set()
+        for item in original_values:
+            val = item.get("value")
+            if val is not None:
+                val_str = str(val).strip()
+                count = value_counts.get(val_str, 0)
+                facet_list.append({"value": val_str, "count": count})
+                seen.add(val_str)
+        for val_str, count in value_counts.items():
+            if val_str not in seen:
+                facet_list.append({"value": val_str, "count": count})
+
+        recalculated[field] = facet_list
+
+    return recalculated
+
+
+def filter_placeholder(message="Search to enable filters."):
+    """Placeholder message when filters are unavailable."""
+    return dbc.Alert(
+        [html.I(className="bi bi-funnel me-2"), message],
+        color="light",
+        className="shadow-sm",
+        style={"borderRadius": "10px"},
+    )
+
+
+def build_filter_controls(
+    facets,
+    selected_filters=None,
+    facet_fields=None,
+    search_mode="targets",
+    id_prefix="",
+):
+    """Build filter controls for facet fields.
+
+    Args:
+        facets: Facet data from the search API.
+        selected_filters: Currently selected filter values.
+        facet_fields: List of facet field names to display.
+        search_mode: 'targets' or 'datasets'.
+        id_prefix: Prefix for component IDs to avoid collisions across pages.
+    """
+    if not facets:
+        return filter_placeholder()
+
+    if selected_filters is None:
+        selected_filters = {}
+
+    if facet_fields is None:
+        facet_fields = FACET_FIELDS
+
+    filter_type = f"{id_prefix}-facet-filter" if id_prefix else "facet-filter"
+
+    field_icons = {
+        "license": "bi-award-fill",
+        "data_modalities": "bi-database",
+        "tissues_tested": "bi-universal-access-circle",
+        "cell_types_tested": "bi-puzzle",
+        "cell_lines_tested": "bi-puzzle-fill",
+        "diseases_tested": "bi-virus2",
+        "sex_tested": "bi-gender-ambiguous",
+        "developmental_stages_tested": "bi-graph-up-arrow",
+        "license_labels": "bi-award-fill",
+        "library_perturbation_type_labels": "bi-database",
+        "tissue_labels": "bi-universal-access-circle",
+        "cell_type_labels": "bi-puzzle",
+        "cell_line_labels": "bi-puzzle-fill",
+        "disease_labels": "bi-virus2",
+        "sex_labels": "bi-gender-ambiguous",
+        "developmental_stage_labels": "bi-graph-up-arrow",
+    }
+
+    field_explanations = {
+        "license": {
+            "header": "License Filter",
+            "body": "Filter targets by the license types of their underlying datasets. Selecting a license shows all targets that have at least one dataset released under that license. Note: A single target may have datasets with different licenses.",
+        },
+        "data_modalities": {
+            "header": "Data Modalities Filter",
+            "body": "Filter targets by experimental approach (Perturb-seq, CRISPR screens, MAVE). Selecting a modality shows all targets that have data from that experimental type. A target may appear in multiple modalities.",
+        },
+        "tissues_tested": {
+            "header": "Tissues Filter",
+            "body": "Filter targets by the tissues used in experiments. Selecting a tissue shows all targets that have been studied in at least one dataset using that tissue. The aggregated results for a target may include data from multiple tissues.",
+        },
+        "cell_types_tested": {
+            "header": "Cell Types Filter",
+            "body": "Filter targets by cell types used in experiments. Selecting a cell type shows all targets studied in at least one dataset using that cell type. A single target's aggregated data may span multiple cell types.",
+        },
+        "cell_lines_tested": {
+            "header": "Cell Lines Filter",
+            "body": "Filter targets by cell lines used in experiments. Selecting a cell line shows all targets studied in at least one dataset using that cell line. A target's aggregated results may include data from multiple cell lines.",
+        },
+        "diseases_tested": {
+            "header": "Diseases Filter",
+            "body": "Filter targets by disease context of experiments. Selecting a disease shows all targets studied in at least one dataset related to that disease. A target may have been studied across multiple disease contexts.",
+        },
+        "sex_tested": {
+            "header": "Sex Filter",
+            "body": "Filter targets by the biological sex of samples used in experiments. Selecting a sex shows all targets studied in at least one dataset using samples of that sex. A target's aggregated data may include both sexes.",
+        },
+        "developmental_stages_tested": {
+            "header": "Developmental Stages Filter",
+            "body": "Filter targets by developmental stage of samples. Selecting a stage shows all targets studied in at least one dataset at that developmental stage. A target may have data across multiple developmental stages.",
+        },
+        "license_labels": {
+            "header": "License Filter",
+            "body": "Filter datasets by the license types under which they are released. Selecting a license shows all datasets released under that license.",
+        },
+        "library_perturbation_type_labels": {
+            "header": "Data Modalities Filter",
+            "body": "Filter datasets by experimental approach (Perturb-seq, CRISPR screens, MAVE). Selecting a modality shows all datasets that have data from that experimental type.",
+        },
+        "tissue_labels": {
+            "header": "Tissues Filter",
+            "body": "Filter datasets by the tissues used in experiments. Selecting a tissue shows all datasets that used that tissue.",
+        },
+        "cell_type_labels": {
+            "header": "Cell Types Filter",
+            "body": "Filter datasets by cell types used in experiments. Selecting a cell type shows all datasets that used that cell type.",
+        },
+        "cell_line_labels": {
+            "header": "Cell Lines Filter",
+            "body": "Filter datasets by cell lines used in experiments. Selecting a cell line shows all datasets that used that cell line.",
+        },
+        "disease_labels": {
+            "header": "Diseases Filter",
+            "body": "Filter datasets by disease context of experiments. Selecting a disease shows all datasets related to that disease.",
+        },
+        "sex_labels": {
+            "header": "Sex Filter",
+            "body": "Filter datasets by the biological sex of samples used in experiments. Selecting a sex shows all datasets using samples of that sex.",
+        },
+        "developmental_stage_labels": {
+            "header": "Developmental Stages Filter",
+            "body": "Filter datasets by developmental stage of samples. Selecting a stage shows all datasets at that developmental stage.",
+        },
+    }
+
+    controls = []
+    for field in facet_fields:
+        values = facets.get(field, [])
+        if not values:
+            continue
+
+        display_name_map = {
+            "license": "License",
+            "data_modalities": "Data Modalities",
+            "tissues_tested": "Tissues",
+            "cell_types_tested": "Cell Types",
+            "cell_lines_tested": "Cell Lines",
+            "sex_tested": "Sex",
+            "developmental_stages_tested": "Developmental Stages",
+            "diseases_tested": "Diseases",
+            "license_labels": "License",
+            "library_perturbation_type_labels": "Data Modalities",
+            "tissue_labels": "Tissues",
+            "cell_type_labels": "Cell Types",
+            "cell_line_labels": "Cell Lines",
+            "disease_labels": "Diseases",
+            "sex_labels": "Sex",
+            "developmental_stage_labels": "Developmental Stages",
+        }
+        if field in display_name_map:
+            display_name = display_name_map[field]
+        else:
+            display_name = field.replace("_", " ").title()
+        options = []
+        option_value_map = {}
+        field_selected = [
+            str(v).strip().lower()
+            for v in selected_filters.get(field, [])
+            if v is not None
+        ]
+        for item in values:
+            raw_value = item.get("value")
+            count = item.get("count", 0)
+            if raw_value is None:
+                continue
+            value = str(raw_value).strip()
+            if not value:
+                continue
+            if count <= 0 and value.lower() not in field_selected:
+                continue
+            options.append({"label": f"{value} ({count})", "value": value})
+            option_value_map[value.lower()] = value
+
+        if not options:
+            continue
+
+        selected_values = []
+        for item in selected_filters.get(field, []):
+            if item is None:
+                continue
+            cleaned_value = str(item).strip()
+            if not cleaned_value:
+                continue
+            mapped_value = option_value_map.get(cleaned_value.lower())
+            if mapped_value and mapped_value not in selected_values:
+                selected_values.append(mapped_value)
+
+        if len(options) <= 10:
+            control = dcc.Checklist(
+                id={"type": filter_type, "field": field},
+                options=options,
+                value=selected_values,
+                inputStyle={"marginRight": "0.5rem"},
+                labelStyle={
+                    "display": "block",
+                    "marginBottom": "0.35rem",
+                    "fontSize": "0.9rem",
+                },
+            )
+        else:
+            control = dcc.Dropdown(
+                id={"type": filter_type, "field": field},
+                options=options,
+                value=selected_values,
+                multi=True,
+                placeholder=f"Filter by {display_name}",
+                className="facet-dropdown",
+                style={
+                    "fontSize": "0.9rem",
+                    "zIndex": 2000,
+                    "position": "relative",
+                },
+            )
+
+        icon_class = field_icons.get(field)
+        explanation = field_explanations.get(field)
+        info_icon_id = (
+            f"{id_prefix}-facet-info-{field}" if id_prefix else f"facet-info-{field}"
+        )
+
+        header_children = []
+        if icon_class:
+            header_children.append(html.I(className=f"bi {icon_class} me-2"))
+
+        header_children.append(f"{display_name} ")
+
+        if explanation and search_mode != "datasets":
+            header_children.append(
+                html.Span(
+                    html.I(className="bi bi-question-circle me-2"),
+                    id=info_icon_id,
+                    style={"cursor": "pointer", "marginLeft": "2px"},
+                )
+            )
+            header_children.append(
+                dbc.Popover(
+                    [
+                        dbc.PopoverHeader(explanation["header"]),
+                        dbc.PopoverBody(explanation["body"]),
+                    ],
+                    target=info_icon_id,
+                    trigger="click",
+                    placement="right",
+                )
+            )
+
+        controls.append(
+            dbc.Card(
+                [
+                    dbc.CardHeader(
+                        header_children,
+                        className="fw-semibold",
+                        style={"backgroundColor": "#f8f9fa"},
+                    ),
+                    dbc.CardBody(control, style={"padding": "0.75rem"}),
+                ],
+                className="mb-3 shadow-sm facet-filter-card",
+                style={
+                    "borderRadius": "12px",
+                    "overflow": "visible",
+                    "position": "relative",
+                    "zIndex": 1,
+                },
+            )
+        )
+
+    if not controls:
+        return filter_placeholder("No filters available for these results.")
+
+    return html.Div(controls, className="facet-controls")

--- a/fe/pages/datasets.py
+++ b/fe/pages/datasets.py
@@ -1,0 +1,605 @@
+"""Browse datasets page for Perturbation Catalogue."""
+
+import dash
+from dash import dcc, html, Input, Output, State, callback, ALL, callback_context
+import dash_bootstrap_components as dbc
+from urllib.parse import parse_qs
+from utils import (
+    COLORS,
+    FACET_FIELDS,
+    fetch_search_results,
+    fetch_all_search_results,
+)
+from components.search_table import (
+    TARGET_TO_DATASET_FIELD,
+    render_datasets_table,
+    recalculate_facets,
+    filter_placeholder,
+    build_filter_controls,
+)
+
+dash.register_page(__name__, path="/datasets", name="Datasets", title="Browse Datasets")
+
+PAGE_SIZE = 10
+
+
+layout = html.Div(
+    [
+        dcc.Location(id="datasets-url", refresh=False),
+        dbc.Container(
+            [
+                html.Div(
+                    [
+                        html.H2("Browse Datasets", className="mb-3 mt-4"),
+                        html.P(
+                            "Explore all datasets in the Perturbation Catalogue. Use the search bar to filter by dataset ID, study title, tissue, disease, and more.",
+                            className="text-muted mb-3",
+                        ),
+                        dbc.InputGroup(
+                            [
+                                dbc.Input(
+                                    id="datasets-search-input",
+                                    placeholder="Search datasets by ID, title, tissue, disease...",
+                                    type="text",
+                                    value="",
+                                    debounce=True,
+                                    className="form-control-lg",
+                                    style={"borderRadius": "8px 0 0 8px"},
+                                ),
+                                dbc.Button(
+                                    [
+                                        html.I(className="bi bi-search me-2"),
+                                        "Search",
+                                    ],
+                                    id="datasets-search-button",
+                                    color="primary",
+                                    n_clicks=0,
+                                    className="btn-lg",
+                                    style={
+                                        "backgroundColor": COLORS["primary"],
+                                        "borderColor": COLORS["primary"],
+                                        "borderRadius": "0 8px 8px 0",
+                                        "paddingLeft": "2rem",
+                                        "paddingRight": "2rem",
+                                    },
+                                ),
+                            ],
+                            className="mb-4",
+                            style={"maxWidth": "700px"},
+                        ),
+                    ]
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.Div(
+                                id="datasets-facets",
+                                className="mt-2",
+                                style={
+                                    "position": "relative",
+                                    "zIndex": 50,
+                                    "overflow": "visible",
+                                },
+                            ),
+                            xs=12,
+                            sm=12,
+                            md=12,
+                            lg=3,
+                            className="mb-4",
+                            style={
+                                "overflow": "visible",
+                                "position": "relative",
+                                "zIndex": 50,
+                            },
+                        ),
+                        dbc.Col(
+                            dcc.Loading(
+                                id="datasets-results-loading",
+                                type="circle",
+                                color=COLORS["primary"],
+                                children=html.Div(
+                                    id="datasets-results",
+                                    className="mt-2",
+                                    children=[
+                                        html.Div(
+                                            id="datasets-download-container",
+                                            className="mb-3",
+                                            style={"display": "none"},
+                                            children=[
+                                                dbc.Button(
+                                                    [
+                                                        html.I(
+                                                            className="bi bi-download me-2"
+                                                        ),
+                                                        "Download Metadata",
+                                                    ],
+                                                    id="datasets-download-btn",
+                                                    color="primary",
+                                                    size="sm",
+                                                    style={
+                                                        "backgroundColor": COLORS[
+                                                            "primary"
+                                                        ],
+                                                        "borderColor": COLORS[
+                                                            "primary"
+                                                        ],
+                                                        "borderRadius": "6px",
+                                                    },
+                                                ),
+                                                dcc.Download(id="datasets-download"),
+                                            ],
+                                        ),
+                                        html.Div(id="datasets-results-table"),
+                                        html.Div(
+                                            id="datasets-pagination",
+                                            className="mt-3 pagination-bar",
+                                            style={"display": "none"},
+                                            children=[
+                                                dbc.Button(
+                                                    [
+                                                        html.I(
+                                                            className="bi bi-arrow-left me-1"
+                                                        ),
+                                                        "Previous",
+                                                    ],
+                                                    id="datasets-page-prev",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    disabled=True,
+                                                    style={"borderRadius": "6px"},
+                                                    className="me-3",
+                                                ),
+                                                html.Span(
+                                                    "Page 1 of 1",
+                                                    id="datasets-page-info",
+                                                    className="fw-semibold me-3",
+                                                ),
+                                                dbc.Button(
+                                                    [
+                                                        "Next",
+                                                        html.I(
+                                                            className="bi bi-arrow-right ms-1"
+                                                        ),
+                                                    ],
+                                                    id="datasets-page-next",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    disabled=True,
+                                                    style={"borderRadius": "6px"},
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                                target_components={
+                                    "datasets-results-table": "children",
+                                    "datasets-pagination": "style",
+                                },
+                                delay_show=200,
+                                delay_hide=100,
+                            ),
+                            xs=12,
+                            sm=12,
+                            md=12,
+                            lg=9,
+                            style={"position": "relative", "zIndex": 10},
+                        ),
+                    ],
+                    className="py-2 g-4",
+                ),
+                dcc.Store(
+                    id="datasets-results-store",
+                    data={
+                        "results": [],
+                        "facets": {},
+                        "query": "",
+                        "total": 0,
+                        "total_pages": 0,
+                        "current_page": 1,
+                        "server_paginated": True,
+                    },
+                ),
+                dcc.Store(id="datasets-page-store", data=1),
+            ],
+            className="content-container",
+        ),
+    ]
+)
+
+
+@callback(
+    Output("datasets-search-input", "value"),
+    Input("datasets-url", "search"),
+)
+def populate_datasets_search_from_url(search):
+    """Populate search input from URL query parameter on initial load."""
+    if search:
+        params = parse_qs(search.lstrip("?"))
+        query = params.get("q", [None])[0]
+        if query:
+            return query[:500]
+    return ""
+
+
+@callback(
+    Output("datasets-results-store", "data"),
+    Input("datasets-search-input", "value"),
+    Input("datasets-search-button", "n_clicks"),
+)
+def load_datasets_data(query, _n_clicks):
+    """Fetch dataset search results from backend."""
+    search_term = (query or "").strip() if query else ""
+
+    if search_term:
+        # Client-side mode: fetch all matches (backend returns up to 1000)
+        data = fetch_search_results(
+            query=search_term,
+            page=1,
+            size=100,
+            search_mode="datasets",
+        )
+        return {
+            "results": data.get("results", []),
+            "facets": data.get("facets", {}),
+            "query": search_term,
+            "total": data.get("total", 0),
+            "total_pages": 1,
+            "current_page": 1,
+            "server_paginated": False,
+        }
+    else:
+        # Server-side mode: fetch first page only
+        data = fetch_search_results(
+            query=None,
+            page=1,
+            size=PAGE_SIZE,
+            search_mode="datasets",
+        )
+        return {
+            "results": data.get("results", []),
+            "facets": data.get("facets", {}),
+            "query": "",
+            "total": data.get("total", 0),
+            "total_pages": data.get("total_pages", 0),
+            "current_page": 1,
+            "server_paginated": True,
+        }
+
+
+@callback(
+    Output("datasets-results-table", "children"),
+    Output("datasets-pagination", "style"),
+    Output("datasets-page-info", "children"),
+    Output("datasets-page-prev", "disabled"),
+    Output("datasets-page-next", "disabled"),
+    Output("datasets-page-store", "data"),
+    Output("datasets-facets", "children"),
+    Output("datasets-download-container", "style"),
+    Input("datasets-results-store", "data"),
+    Input({"type": "datasets-facet-filter", "field": ALL}, "value"),
+    Input("datasets-page-prev", "n_clicks"),
+    Input("datasets-page-next", "n_clicks"),
+    State({"type": "datasets-facet-filter", "field": ALL}, "id"),
+    State("datasets-page-store", "data"),
+)
+def render_datasets_results(
+    store_data, selected_values, prev_clicks, next_clicks, filter_ids, current_page
+):
+    """Render dataset results with server-side or client-side filtering and pagination."""
+    ctx = callback_context
+    trigger = ctx.triggered[0]["prop_id"] if ctx.triggered else None
+
+    if not store_data or not store_data.get("results"):
+        return (
+            filter_placeholder("No datasets found. Try a search query."),
+            {"display": "none"},
+            "Page 1 of 1",
+            True,
+            True,
+            1,
+            filter_placeholder("Search to see available filters."),
+            {"display": "none"},
+        )
+
+    # Build selected filters dict
+    selected_filters = {}
+    if selected_values and filter_ids:
+        for values, filter_id in zip(selected_values, filter_ids):
+            if values:
+                cleaned = [str(v).strip() for v in values if v not in (None, "")]
+                if cleaned:
+                    selected_filters[filter_id["field"]] = cleaned
+
+    server_paginated = store_data.get("server_paginated", False)
+    triggered_prop = trigger or ""
+
+    if server_paginated:
+        # --- SERVER-SIDE PAGINATION MODE ---
+        return _render_server_side(
+            store_data, selected_filters, triggered_prop, current_page
+        )
+    else:
+        # --- CLIENT-SIDE FILTERING MODE ---
+        return _render_client_side(
+            store_data, selected_filters, triggered_prop, current_page
+        )
+
+
+def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
+    """Handle rendering in server-side pagination mode (no query)."""
+    current_page_number = store_data.get("current_page", 1) or 1
+
+    if "datasets-results-store" in triggered_prop:
+        # Initial load or new search: use data from store directly
+        results = store_data.get("results", [])
+        facets = store_data.get("facets", {})
+        total = store_data.get("total", 0)
+        total_pages = store_data.get("total_pages", 0)
+        current_page_number = store_data.get("current_page", 1)
+    elif "datasets-page-prev" in triggered_prop:
+        current_page_number = max(1, (current_page or 1) - 1)
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=current_page_number,
+            size=PAGE_SIZE,
+            search_mode="datasets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    elif "datasets-page-next" in triggered_prop:
+        old_total_pages = store_data.get("total_pages", 1)
+        current_page_number = min(old_total_pages, (current_page or 1) + 1)
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=current_page_number,
+            size=PAGE_SIZE,
+            search_mode="datasets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    elif "facet-filter" in triggered_prop:
+        # Facet changed: reset to page 1 with new filters
+        current_page_number = 1
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=1,
+            size=PAGE_SIZE,
+            search_mode="datasets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    else:
+        # Fallback: use store data
+        results = store_data.get("results", [])
+        facets = store_data.get("facets", {})
+        total = store_data.get("total", 0)
+        total_pages = store_data.get("total_pages", 0)
+        current_page_number = store_data.get("current_page", 1)
+
+    total_pages = max(1, total_pages)
+    if current_page_number > total_pages:
+        current_page_number = total_pages
+    if current_page_number < 1:
+        current_page_number = 1
+
+    if not results and total == 0:
+        filters_children = build_filter_controls(
+            facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+        )
+        return (
+            dbc.Alert(
+                [
+                    html.I(className="bi bi-info-circle me-2"),
+                    "No datasets found matching your filters.",
+                ],
+                color="info",
+                className="shadow-sm",
+                style={"borderRadius": "10px"},
+            ),
+            {"display": "none"},
+            f"Page 1 of 1 ({total} results)",
+            True,
+            True,
+            current_page_number,
+            filters_children,
+            {"display": "none"},
+        )
+
+    table = render_datasets_table(results)
+    filters_children = build_filter_controls(
+        facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+    )
+
+    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
+    page_info = f"Page {current_page_number} of {total_pages} ({total} results)"
+    prev_disabled = current_page_number <= 1
+    next_disabled = current_page_number >= total_pages
+
+    return (
+        table,
+        pagination_style,
+        page_info,
+        prev_disabled,
+        next_disabled,
+        current_page_number,
+        filters_children,
+        {"display": "flex", "justifyContent": "flex-end"},
+    )
+
+
+def _render_client_side(store_data, selected_filters, triggered_prop, current_page):
+    """Handle rendering in client-side filtering mode (with query)."""
+    all_results = store_data.get("results", [])
+    original_facets = store_data.get("facets", {})
+
+    # Apply client-side filtering
+    def matches_filters(result, filters):
+        for field, sel_values in filters.items():
+            if not sel_values:
+                continue
+            actual_field = TARGET_TO_DATASET_FIELD.get(field, field)
+            result_value = result.get(actual_field)
+            if result_value is None:
+                return False
+            if isinstance(result_value, list):
+                if not any(v in sel_values for v in result_value):
+                    return False
+            else:
+                if result_value not in sel_values:
+                    return False
+        return True
+
+    if selected_filters:
+        filtered_results = [
+            r for r in all_results if matches_filters(r, selected_filters)
+        ]
+    else:
+        filtered_results = all_results
+
+    # Recalculate facet counts
+    if selected_filters:
+        facets = recalculate_facets(filtered_results, original_facets, "datasets")
+    else:
+        facets = original_facets
+
+    # Pagination
+    total_results = len(filtered_results)
+    total_pages = max(1, (total_results + PAGE_SIZE - 1) // PAGE_SIZE)
+
+    current_page_number = current_page or 1
+
+    if "datasets-results-store" in triggered_prop or "facet-filter" in triggered_prop:
+        current_page_number = 1
+    elif "datasets-page-prev" in triggered_prop:
+        current_page_number = max(1, current_page_number - 1)
+    elif "datasets-page-next" in triggered_prop:
+        current_page_number = min(total_pages, current_page_number + 1)
+
+    if current_page_number > total_pages:
+        current_page_number = total_pages
+    if current_page_number < 1:
+        current_page_number = 1
+
+    start_idx = (current_page_number - 1) * PAGE_SIZE
+    end_idx = start_idx + PAGE_SIZE
+    page_results = filtered_results[start_idx:end_idx]
+
+    if not page_results and total_results == 0:
+        filters_children = build_filter_controls(
+            facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+        )
+        return (
+            dbc.Alert(
+                [
+                    html.I(className="bi bi-info-circle me-2"),
+                    "No datasets found matching your filters.",
+                ],
+                color="info",
+                className="shadow-sm",
+                style={"borderRadius": "10px"},
+            ),
+            {"display": "none"},
+            f"Page 1 of {total_pages} ({total_results} results)",
+            True,
+            True,
+            current_page_number,
+            filters_children,
+            {"display": "none"},
+        )
+
+    table = render_datasets_table(page_results)
+    filters_children = build_filter_controls(
+        facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+    )
+
+    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
+    page_info = f"Page {current_page_number} of {total_pages} ({total_results} results)"
+    prev_disabled = current_page_number <= 1
+    next_disabled = current_page_number >= total_pages
+
+    return (
+        table,
+        pagination_style,
+        page_info,
+        prev_disabled,
+        next_disabled,
+        current_page_number,
+        filters_children,
+        {"display": "flex", "justifyContent": "flex-end"},
+    )
+
+
+@callback(
+    Output("datasets-download", "data"),
+    Input("datasets-download-btn", "n_clicks"),
+    State("datasets-results-store", "data"),
+    State({"type": "datasets-facet-filter", "field": ALL}, "value"),
+    State({"type": "datasets-facet-filter", "field": ALL}, "id"),
+    prevent_initial_call=True,
+)
+def download_datasets_metadata(n_clicks, store_data, selected_values, filter_ids):
+    """Download all dataset results as CSV."""
+    if not n_clicks or not store_data:
+        return dash.no_update
+
+    query = store_data.get("query")
+
+    selected_filters = {}
+    if selected_values and filter_ids:
+        for values, filter_id in zip(selected_values, filter_ids):
+            if values:
+                cleaned = [str(v).strip() for v in values if v not in (None, "")]
+                if cleaned:
+                    selected_filters[filter_id["field"]] = cleaned
+
+    all_results = fetch_all_search_results(
+        query=query if query else None,
+        filters=selected_filters or None,
+        search_mode="datasets",
+    )
+
+    if not all_results:
+        return dash.no_update
+
+    columns = [
+        "dataset_id",
+        "study_title",
+        "study_year",
+        "data_modalities",
+    ]
+
+    csv_lines = [",".join(columns)]
+    for record in all_results:
+        row_values = []
+        for col in columns:
+            value = record.get(col, "")
+            if isinstance(value, list):
+                value = "; ".join(str(v) for v in value)
+            elif value is None:
+                value = ""
+            else:
+                value = str(value)
+            # Sanitize formula injection characters
+            if value and value[0:1] in ("=", "+", "-", "@", "\t", "\r"):
+                value = "'" + value
+            if "," in value or '"' in value or "\n" in value:
+                value = '"' + value.replace('"', '""') + '"'
+            row_values.append(value)
+        csv_lines.append(",".join(row_values))
+
+    csv_content = "\n".join(csv_lines)
+    safe_query = "".join(
+        c if c.isalnum() or c in "-_" else "_" for c in (query or "all")[:30]
+    )
+    filename = f"perturbation_catalogue_datasets_{safe_query}.csv"
+
+    return dict(content=csv_content, filename=filename, type="text/csv")

--- a/fe/pages/home.py
+++ b/fe/pages/home.py
@@ -1,445 +1,17 @@
 """Home page for Perturbation Search"""
 
 import dash
-from dash import dcc, html, Input, Output, State, callback, ALL, callback_context
+from dash import dcc, html, Input, Output, State, callback, callback_context
 import dash_bootstrap_components as dbc
 import plotly.graph_objects as go
 from urllib.parse import quote
 from utils import (
     COLORS,
-    DATA_MODALITIES_COLOURS,
-    FACET_FIELDS,
-    fetch_search_results,
-    fetch_all_search_results,
     get_landing_page_summary,
-    results_store,
-    format_value,
 )
-
-SEARCH_RESULTS_PAGE_SIZE = 15
-
-# Mapping from canonical (target) field names to dataset index field names.
-# Used for client-side filtering of dataset results.
-TARGET_TO_DATASET_FIELD = {
-    "license": "license_labels",
-    "data_modalities": "data_modalities",
-    "tissues_tested": "tissue_labels",
-    "cell_types_tested": "cell_type_labels",
-    "cell_lines_tested": "cell_line_labels",
-    "sex_tested": "sex_labels",
-    "developmental_stages_tested": "developmental_stage_labels",
-    "diseases_tested": "disease_labels",
-}
-
 
 # Register this page with Dash Pages
 dash.register_page(__name__, path="/")
-
-
-def _format_count(value):
-    """Format numeric counts for display, falling back to '0' when missing."""
-    if value in (None, "", "N/A"):
-        return "0"
-    if isinstance(value, (int, float)):
-        return f"{int(value):,}" if isinstance(value, int) else format_value(value)
-    return format_value(value)
-
-
-def _render_search_results(results):
-    """Render the search results table for the provided entries."""
-    # Clear previous cache and repopulate with current results
-    results_store.clear()
-
-    if not results:
-        return dbc.Alert(
-            [
-                html.I(className="bi bi-info-circle me-2"),
-                "No results found. Try another target name.",
-            ],
-            color="info",
-            className="shadow-sm",
-            style={"borderRadius": "10px"},
-        )
-
-    header = html.Thead(
-        html.Tr(
-            [
-                html.Th(
-                    [
-                        "Target name ",
-                        html.Span(
-                            html.I(className="bi bi-question-circle"),
-                            id="target-info-icon",
-                            style={"cursor": "pointer", "color": "#6c757d"},
-                        ),
-                        dbc.Popover(
-                            [
-                                dbc.PopoverHeader("Target Gene Aggregation"),
-                                dbc.PopoverBody(
-                                    "Results are aggregated by target gene name. Each row represents all datasets and modalities available for a specific target, combining data from Perturb-seq, CRISPR screens, and MAVE experiments across different tissues, cell types, and experimental conditions."
-                                ),
-                            ],
-                            target="target-info-icon",
-                            trigger="click",
-                            placement="bottom",
-                        ),
-                    ],
-                    className="fw-semibold",
-                ),
-                html.Th("Perturb-seq datasets", className="fw-semibold text-center"),
-                html.Th(
-                    "CRISPR-screen datasets",
-                    className="fw-semibold text-center",
-                ),
-                html.Th(
-                    "MAVE datasets",
-                    className="fw-semibold text-center",
-                ),
-                html.Th(
-                    [
-                        "Top GSEA Terms ",
-                        html.Span(
-                            html.I(className="bi bi-question-circle"),
-                            id="gsea-info-icon",
-                            style={"cursor": "pointer", "color": "#6c757d"},
-                        ),
-                        dbc.Popover(
-                            [
-                                dbc.PopoverHeader("Pathway enrichment (GSEA)"),
-                                dbc.PopoverBody(
-                                    "Shows biological pathways whose genes are collectively up- or down-regulated after a genetic perturbation, based on single-cell Perturb-seq data and MSigDB Hallmark gene sets."
-                                ),
-                            ],
-                            target="gsea-info-icon",
-                            trigger="click",
-                            placement="bottom",
-                        ),
-                    ],
-                    className="fw-semibold",
-                ),
-                html.Th("Data Modalities", className="fw-semibold"),
-            ],
-            style={"backgroundColor": "#f1f3f5"},
-        )
-    )
-
-    rows = []
-    for record in results:
-        symbol = record.get("perturbed_target_symbol", "N/A")
-        results_store[symbol] = record
-
-        n_sc_perturb_seq = _format_count(record.get("n_perturb_seq"))
-        n_sc_perturb_seq_up = _format_count(record.get("n_sig_perturb_pairs_up"))
-        n_sc_perturb_seq_down = _format_count(record.get("n_sig_perturb_pairs_down"))
-        n_crispr = _format_count(record.get("n_crispr"))
-        n_sig_crispr = _format_count(record.get("n_sig_crispr"))
-        n_mave = _format_count(record.get("n_mave"))
-        top_gsea_terms = record.get("top_gsea_terms") or []
-        data_modalities = record.get("data_modalities") or []
-
-        gsea_badges = []
-        for term in top_gsea_terms[:5]:  # Limit to 5 terms
-            # Truncate long terms for display
-            display_term = term if len(term) <= 25 else term[:22] + "..."
-            gsea_badges.append(
-                html.Span(
-                    dbc.Badge(
-                        display_term,
-                        color="light",
-                        className="me-1 mb-1",
-                        style={
-                            "fontSize": "0.65rem",
-                            "border": "1px solid #6c757d",
-                            "color": "#495057",
-                            "backgroundColor": "#f8f9fa",
-                            "whiteSpace": "nowrap",
-                            "overflow": "hidden",
-                            "textOverflow": "ellipsis",
-                            "maxWidth": "150px",
-                            "display": "inline-block",
-                        },
-                    ),
-                    title=term,  # Full term shown on hover
-                )
-            )
-        if not gsea_badges:
-            gsea_badges = [html.Span("No significant hits were found", className="text-muted", style={"fontSize": "0.8rem"})]
-
-        modalities_badges = []
-        for modality in data_modalities:
-            badge_color = DATA_MODALITIES_COLOURS.get(modality, COLORS["primary"])
-            modalities_badges.append(
-                dbc.Badge(
-                    modality,
-                    color="light",
-                    className="me-1 mb-1",
-                    style={
-                        "fontSize": "0.75rem",
-                        "border": f"1px solid {badge_color}",
-                        "color": badge_color,
-                        "backgroundColor": f"{badge_color}1A",
-                    },
-                )
-            )
-        if not modalities_badges:
-            modalities_badges = [html.Span("N/A", className="text-muted")]
-
-        rows.append(
-            html.Tr(
-                [
-                    html.Td(
-                        dcc.Link(
-                            symbol,
-                            href=f"/perturbation-catalogue/target/{quote(symbol, safe='')}",
-                            className="text-decoration-none fw-semibold",
-                            style={"color": COLORS["primary"]},
-                        )
-                    ),
-                    html.Td(
-                        [
-                            html.Div(
-                                [
-                                    html.Span(
-                                        f"Datasets: {n_sc_perturb_seq} ",
-                                        style={
-                                            "marginRight": "5px",
-                                        },
-                                    ),
-                                    html.Span(
-                                        [
-                                            html.Span("("),
-                                            html.Span(
-                                                "Sig. genes up ↑: ",
-                                                style={
-                                                    "color": "#1f9d55",
-                                                    "marginRight": "0.25rem",
-                                                    "fontWeight": "600",
-                                                },
-                                            ),
-                                            html.Span(
-                                                n_sc_perturb_seq_up,
-                                                style={
-                                                    "color": "#1f9d55",
-                                                    "fontWeight": "600",
-                                                },
-                                            ),
-                                            html.Span(";"),
-                                        ],
-                                        className="d-inline-flex align-items-center me-3",
-                                    ),
-                                    html.Span(
-                                        [
-                                            html.Span(
-                                                "Sig. genes down ↓: ",
-                                                style={
-                                                    "color": "#c53030",
-                                                    "marginRight": "0.25rem",
-                                                    "fontWeight": "600",
-                                                },
-                                            ),
-                                            html.Span(
-                                                n_sc_perturb_seq_down,
-                                                style={
-                                                    "color": "#c53030",
-                                                    "fontWeight": "600",
-                                                },
-                                            ),
-                                            html.Span(")"),
-                                        ],
-                                        className="d-inline-flex align-items-center",
-                                    ),
-                                ],
-                                className="d-flex justify-content-center flex-wrap",
-                            )
-                        ],
-                        className="text-center",
-                    ),
-                    html.Td(
-                        html.Div(
-                            [
-                                html.Span(
-                                    f"Datasets: {n_crispr}",
-                                    style={
-                                        "marginRight": "5px",
-                                    },
-                                ),
-                                html.Span(
-                                    f"Sig. hits: {n_sig_crispr}",
-                                    style={
-                                        "color": "#1f9d55",
-                                        "marginRight": "0.25rem",
-                                        "fontWeight": "600",
-                                    },
-                                ),
-                            ],
-                            className="d-flex justify-content-center flex-wrap",
-                        ),
-                        className="text-center",
-                    ),
-                    html.Td(n_mave, className="text-center"),
-                    html.Td(
-                        html.Div(gsea_badges, className="d-flex flex-wrap"),
-                        style={
-                            "maxWidth": "180px",
-                            "minWidth": "120px",
-                            "overflow": "hidden",
-                        },
-                    ),
-                    html.Td(modalities_badges),
-                ]
-            )
-        )
-
-    table = dbc.Table(
-        [header, html.Tbody(rows)],
-        bordered=False,
-        hover=True,
-        responsive=True,
-        striped=False,
-        className="align-middle shadow-sm",
-        style={"borderRadius": "12px", "overflow": "hidden"},
-    )
-
-    return table
-
-
-def _recalculate_facets(filtered_results, original_facets, search_mode="targets"):
-    """Recalculate facet counts based on currently filtered results."""
-    is_dataset_mode = search_mode == "datasets"
-    recalculated = {}
-    for field in FACET_FIELDS:
-        value_counts = {}
-        # In dataset mode, result fields use different names (e.g. cell_type_labels vs cell_types_tested)
-        result_field = TARGET_TO_DATASET_FIELD.get(field, field) if is_dataset_mode else field
-        for result in filtered_results:
-            field_value = result.get(result_field)
-            if field_value is None:
-                continue
-            if isinstance(field_value, list):
-                for v in field_value:
-                    v_str = str(v).strip()
-                    if v_str:
-                        value_counts[v_str] = value_counts.get(v_str, 0) + 1
-            else:
-                v_str = str(field_value).strip()
-                if v_str:
-                    value_counts[v_str] = value_counts.get(v_str, 0) + 1
-
-        # Preserve original ordering, update counts
-        original_values = original_facets.get(field, [])
-        facet_list = []
-        seen = set()
-        for item in original_values:
-            val = item.get("value")
-            if val is not None:
-                val_str = str(val).strip()
-                count = value_counts.get(val_str, 0)
-                facet_list.append({"value": val_str, "count": count})
-                seen.add(val_str)
-        for val_str, count in value_counts.items():
-            if val_str not in seen:
-                facet_list.append({"value": val_str, "count": count})
-
-        recalculated[field] = facet_list
-
-    return recalculated
-
-
-def _render_dataset_search_results(results):
-    """Render the search results table for dataset search results."""
-    if not results:
-        return dbc.Alert(
-            [
-                html.I(className="bi bi-info-circle me-2"),
-                "No datasets found. Try another search term.",
-            ],
-            color="info",
-            className="shadow-sm",
-            style={"borderRadius": "10px"},
-        )
-
-    header = html.Thead(
-        html.Tr(
-            [
-                html.Th("Dataset ID", className="fw-semibold"),
-                html.Th("Study Title", className="fw-semibold"),
-                html.Th("Study Year", className="fw-semibold text-center"),
-                html.Th("Data Modality", className="fw-semibold"),
-            ],
-            style={"backgroundColor": "#f1f3f5"},
-        )
-    )
-
-    rows = []
-    for record in results:
-        dataset_id = record.get("dataset_id", "N/A")
-        study_title = record.get("study_title") or record.get("experiment_title") or "N/A"
-        # Truncate long titles
-        display_title = study_title if len(study_title) <= 60 else study_title[:57] + "..."
-        modality = record.get("data_modalities") or []
-        year = record.get("study_year") or "N/A"
-
-        modality_badges = []
-        for mod in modality:
-            badge_color = DATA_MODALITIES_COLOURS.get(mod, COLORS["primary"])
-            modality_badges.append(
-                dbc.Badge(
-                    mod,
-                    color="light",
-                    className="me-1 mb-1",
-                    style={
-                        "fontSize": "0.75rem",
-                        "border": f"1px solid {badge_color}",
-                        "color": badge_color,
-                        "backgroundColor": f"{badge_color}1A",
-                    },
-                )
-            )
-        if not modality_badges:
-            modality_badges = [html.Span("N/A", className="text-muted")]
-
-        rows.append(
-            html.Tr(
-                [
-                    html.Td(
-                        dcc.Link(
-                            dataset_id,
-                            href=f"/perturbation-catalogue/dataset/{dataset_id}",
-                            className="text-decoration-none fw-semibold",
-                            style={"color": COLORS["primary"]},
-                        )
-                    ),
-                    html.Td(
-                        html.Span(display_title, title=study_title),
-                        style={"maxWidth": "300px"},
-                    ),
-                    html.Td(str(year), className="text-center"),
-                    html.Td(html.Div(modality_badges, className="d-flex flex-wrap")),
-                ]
-            )
-        )
-
-    table = dbc.Table(
-        [header, html.Tbody(rows)],
-        bordered=False,
-        hover=True,
-        responsive=True,
-        striped=False,
-        className="align-middle shadow-sm",
-        style={"borderRadius": "12px", "overflow": "hidden"},
-    )
-
-    return table
-
-
-def _filter_placeholder(message="Search to enable filters."):
-    """Placeholder message when filters are unavailable."""
-    return dbc.Alert(
-        [html.I(className="bi bi-funnel me-2"), message],
-        color="light",
-        className="shadow-sm",
-        style={"borderRadius": "10px"},
-    )
 
 
 def _format_summary_number(value):
@@ -533,7 +105,6 @@ def _build_summary_list_section(title, items, max_items=6):
                 yaxis=dict(autorange="reversed"),
             )
 
-        # Add indicator if we truncated items
         chart = dcc.Graph(
             figure=fig, config={"displayModeBar": False}, className="summary-chart"
         )
@@ -844,255 +415,10 @@ def _build_summary_component(summary_data, error=None):
     )
 
 
-def _build_filter_controls(facets, selected_filters=None, facet_fields=None, search_mode="targets"):
-    """Build filter controls for facet fields."""
-    if not facets:
-        return _filter_placeholder()
-
-    if selected_filters is None:
-        selected_filters = {}
-
-    if facet_fields is None:
-        facet_fields = FACET_FIELDS
-
-    # Icon mapping for facet fields (covers both target and dataset field names)
-    field_icons = {
-        "license": "bi-award-fill",
-        "data_modalities": "bi-database",
-        "tissues_tested": "bi-universal-access-circle",
-        "cell_types_tested": "bi-puzzle",
-        "cell_lines_tested": "bi-puzzle-fill",
-        "diseases_tested": "bi-virus2",
-        "sex_tested": "bi-gender-ambiguous",
-        "developmental_stages_tested": "bi-graph-up-arrow",
-        # Dataset-mode fields
-        "license_labels": "bi-award-fill",
-        "library_perturbation_type_labels": "bi-database",
-        "tissue_labels": "bi-universal-access-circle",
-        "cell_type_labels": "bi-puzzle",
-        "cell_line_labels": "bi-puzzle-fill",
-        "disease_labels": "bi-virus2",
-        "sex_labels": "bi-gender-ambiguous",
-        "developmental_stage_labels": "bi-graph-up-arrow",
-    }
-
-    # Explanations for facet fields (shown in popover)
-    field_explanations = {
-        "license": {
-            "header": "License Filter",
-            "body": "Filter targets by the license types of their underlying datasets. Selecting a license shows all targets that have at least one dataset released under that license. Note: A single target may have datasets with different licenses.",
-        },
-        "data_modalities": {
-            "header": "Data Modalities Filter",
-            "body": "Filter targets by experimental approach (Perturb-seq, CRISPR screens, MAVE). Selecting a modality shows all targets that have data from that experimental type. A target may appear in multiple modalities.",
-        },
-        "tissues_tested": {
-            "header": "Tissues Filter",
-            "body": "Filter targets by the tissues used in experiments. Selecting a tissue shows all targets that have been studied in at least one dataset using that tissue. The aggregated results for a target may include data from multiple tissues.",
-        },
-        "cell_types_tested": {
-            "header": "Cell Types Filter",
-            "body": "Filter targets by cell types used in experiments. Selecting a cell type shows all targets studied in at least one dataset using that cell type. A single target's aggregated data may span multiple cell types.",
-        },
-        "cell_lines_tested": {
-            "header": "Cell Lines Filter",
-            "body": "Filter targets by cell lines used in experiments. Selecting a cell line shows all targets studied in at least one dataset using that cell line. A target's aggregated results may include data from multiple cell lines.",
-        },
-        "diseases_tested": {
-            "header": "Diseases Filter",
-            "body": "Filter targets by disease context of experiments. Selecting a disease shows all targets studied in at least one dataset related to that disease. A target may have been studied across multiple disease contexts.",
-        },
-        "sex_tested": {
-            "header": "Sex Filter",
-            "body": "Filter targets by the biological sex of samples used in experiments. Selecting a sex shows all targets studied in at least one dataset using samples of that sex. A target's aggregated data may include both sexes.",
-        },
-        "developmental_stages_tested": {
-            "header": "Developmental Stages Filter",
-            "body": "Filter targets by developmental stage of samples. Selecting a stage shows all targets studied in at least one dataset at that developmental stage. A target may have data across multiple developmental stages.",
-        },
-        # Dataset-mode field explanations
-        "license_labels": {
-            "header": "License Filter",
-            "body": "Filter datasets by the license types under which they are released. Selecting a license shows all datasets released under that license.",
-        },
-        "library_perturbation_type_labels": {
-            "header": "Data Modalities Filter",
-            "body": "Filter datasets by experimental approach (Perturb-seq, CRISPR screens, MAVE). Selecting a modality shows all datasets that have data from that experimental type.",
-        },
-        "tissue_labels": {
-            "header": "Tissues Filter",
-            "body": "Filter datasets by the tissues used in experiments. Selecting a tissue shows all datasets that used that tissue.",
-        },
-        "cell_type_labels": {
-            "header": "Cell Types Filter",
-            "body": "Filter datasets by cell types used in experiments. Selecting a cell type shows all datasets that used that cell type.",
-        },
-        "cell_line_labels": {
-            "header": "Cell Lines Filter",
-            "body": "Filter datasets by cell lines used in experiments. Selecting a cell line shows all datasets that used that cell line.",
-        },
-        "disease_labels": {
-            "header": "Diseases Filter",
-            "body": "Filter datasets by disease context of experiments. Selecting a disease shows all datasets related to that disease.",
-        },
-        "sex_labels": {
-            "header": "Sex Filter",
-            "body": "Filter datasets by the biological sex of samples used in experiments. Selecting a sex shows all datasets using samples of that sex.",
-        },
-        "developmental_stage_labels": {
-            "header": "Developmental Stages Filter",
-            "body": "Filter datasets by developmental stage of samples. Selecting a stage shows all datasets at that developmental stage.",
-        },
-    }
-
-    controls = []
-    for field in facet_fields:
-        values = facets.get(field, [])
-        if not values:
-            continue
-
-        # Custom display names for specific fields
-        display_name_map = {
-            # Target-mode fields
-            "license": "License",
-            "data_modalities": "Data Modalities",
-            "tissues_tested": "Tissues",
-            "cell_types_tested": "Cell Types",
-            "cell_lines_tested": "Cell Lines",
-            "sex_tested": "Sex",
-            "developmental_stages_tested": "Developmental Stages",
-            "diseases_tested": "Diseases",
-            # Dataset-mode fields
-            "license_labels": "License",
-            "library_perturbation_type_labels": "Data Modalities",
-            "tissue_labels": "Tissues",
-            "cell_type_labels": "Cell Types",
-            "cell_line_labels": "Cell Lines",
-            "disease_labels": "Diseases",
-            "sex_labels": "Sex",
-            "developmental_stage_labels": "Developmental Stages",
-        }
-        if field in display_name_map:
-            display_name = display_name_map[field]
-        else:
-            display_name = field.replace("_", " ").title()
-        options = []
-        option_value_map = {}
-        field_selected = [str(v).strip().lower() for v in selected_filters.get(field, []) if v is not None]
-        for item in values:
-            raw_value = item.get("value")
-            count = item.get("count", 0)
-            if raw_value is None:
-                continue
-            value = str(raw_value).strip()
-            if not value:
-                continue
-            # Keep values with count 0 if they are currently selected, so user can deselect
-            if count <= 0 and value.lower() not in field_selected:
-                continue
-            options.append({"label": f"{value} ({count})", "value": value})
-            option_value_map[value.lower()] = value
-
-        if not options:
-            continue
-
-        selected_values = []
-        for item in selected_filters.get(field, []):
-            if item is None:
-                continue
-            cleaned_value = str(item).strip()
-            if not cleaned_value:
-                continue
-            mapped_value = option_value_map.get(cleaned_value.lower())
-            if mapped_value and mapped_value not in selected_values:
-                selected_values.append(mapped_value)
-
-        if len(options) <= 10:
-            control = dcc.Checklist(
-                id={"type": "facet-filter", "field": field},
-                options=options,
-                value=selected_values,
-                inputStyle={"marginRight": "0.5rem"},
-                labelStyle={
-                    "display": "block",
-                    "marginBottom": "0.35rem",
-                    "fontSize": "0.9rem",
-                },
-            )
-        else:
-            control = dcc.Dropdown(
-                id={"type": "facet-filter", "field": field},
-                options=options,
-                value=selected_values,
-                multi=True,
-                placeholder=f"Filter by {display_name}",
-                className="facet-dropdown",
-                style={"fontSize": "0.9rem", "zIndex": 2000, "position": "relative"},
-            )
-
-        # Build header with icon and explanation popover
-        icon_class = field_icons.get(field)
-        explanation = field_explanations.get(field)
-        info_icon_id = f"facet-info-{field}"
-
-        # Build the header content matching GSEA tooltip structure exactly
-        header_children = []
-        if icon_class:
-            header_children.append(html.I(className=f"bi {icon_class} me-2"))
-
-        header_children.append(f"{display_name} ")
-
-        # Add info icon and popover if explanation exists (target mode only)
-        if explanation and search_mode != "datasets":
-            header_children.append(
-                html.Span(
-                    html.I(className="bi bi-question-circle me-2"),
-                    id=info_icon_id,
-                    style={"cursor": "pointer", "marginLeft": "2px"},
-                )
-            )
-            header_children.append(
-                dbc.Popover(
-                    [
-                        dbc.PopoverHeader(explanation["header"]),
-                        dbc.PopoverBody(explanation["body"]),
-                    ],
-                    target=info_icon_id,
-                    trigger="click",
-                    placement="right",
-                )
-            )
-
-
-        controls.append(
-            dbc.Card(
-                [
-                    dbc.CardHeader(
-                        header_children,
-                        className="fw-semibold",
-                        style={"backgroundColor": "#f8f9fa"},
-                    ),
-                    dbc.CardBody(control, style={"padding": "0.75rem"}),
-                ],
-                className="mb-3 shadow-sm facet-filter-card",
-                style={
-                    "borderRadius": "12px",
-                    "overflow": "visible",
-                    "position": "relative",
-                    "zIndex": 1,
-                },
-            )
-        )
-
-    if not controls:
-        return _filter_placeholder("No filters available for these results.")
-
-    return html.Div(controls, className="facet-controls")
-
-
 # Layout for home page
 layout = html.Div(
     [
+        dcc.Location(id="home-redirect", refresh=True),
         html.Div(
             [
                 dbc.Container(
@@ -1117,7 +443,9 @@ layout = html.Div(
                                                             dbc.InputGroupText(
                                                                 [
                                                                     html.Span(
-                                                                        html.I(className="bi bi-question-circle"),
+                                                                        html.I(
+                                                                            className="bi bi-question-circle"
+                                                                        ),
                                                                         id="search-mode-info-icon",
                                                                         style={
                                                                             "cursor": "pointer",
@@ -1126,14 +454,20 @@ layout = html.Div(
                                                                     ),
                                                                     dbc.Popover(
                                                                         [
-                                                                            dbc.PopoverHeader("Search Mode"),
+                                                                            dbc.PopoverHeader(
+                                                                                "Search Mode"
+                                                                            ),
                                                                             dbc.PopoverBody(
                                                                                 [
-                                                                                    html.Strong("Targets:"),
+                                                                                    html.Strong(
+                                                                                        "Targets:"
+                                                                                    ),
                                                                                     " Search for gene targets across all experiments. Results show aggregated data for each target gene, including the number of datasets, significant perturbation effects, and pathway enrichment across Perturb-seq, CRISPR, and MAVE experiments.",
                                                                                     html.Br(),
                                                                                     html.Br(),
-                                                                                    html.Strong("Datasets:"),
+                                                                                    html.Strong(
+                                                                                        "Datasets:"
+                                                                                    ),
                                                                                     " Search for datasets by metadata fields such as dataset ID, study title, tissue, cell type, disease, and more. Results show individual experiments with their study details, publication year, and data modality.",
                                                                                 ]
                                                                             ),
@@ -1152,8 +486,14 @@ layout = html.Div(
                                                             dbc.Select(
                                                                 id="search-mode-dropdown",
                                                                 options=[
-                                                                    {"label": "Targets", "value": "targets"},
-                                                                    {"label": "Datasets", "value": "datasets"},
+                                                                    {
+                                                                        "label": "Targets",
+                                                                        "value": "targets",
+                                                                    },
+                                                                    {
+                                                                        "label": "Datasets",
+                                                                        "value": "datasets",
+                                                                    },
                                                                 ],
                                                                 value="targets",
                                                                 className="form-select-lg",
@@ -1314,130 +654,6 @@ layout = html.Div(
                         xs=12,
                     )
                 ),
-                dbc.Row(
-                    [
-                        dbc.Col(
-                            html.Div(
-                                id="facet-filters",
-                                className="mt-4",
-                                style={
-                                    "position": "relative",
-                                    "zIndex": 50,
-                                    "overflow": "visible",
-                                    "display": "none",
-                                },
-                            ),
-                            xs=12,
-                            sm=12,
-                            md=12,
-                            lg=3,
-                            className="mb-4",
-                            style={
-                                "overflow": "visible",
-                                "position": "relative",
-                                "zIndex": 50,
-                            },
-                        ),
-                        dbc.Col(
-                            dcc.Loading(
-                                id="search-results-loading",
-                                type="circle",
-                                color=COLORS["primary"],
-                                children=html.Div(
-                                    id="search-results",
-                                    className="mt-4",
-                                    children=[
-                                        html.Div(
-                                            id="download-metadata-container",
-                                            className="mb-3",
-                                            style={"display": "none"},
-                                            children=[
-                                                dbc.Button(
-                                                    [
-                                                        html.I(
-                                                            className="bi bi-download me-2"
-                                                        ),
-                                                        "Download Metadata",
-                                                    ],
-                                                    id="download-metadata-btn",
-                                                    color="primary",
-                                                    size="sm",
-                                                    style={
-                                                        "backgroundColor": COLORS[
-                                                            "primary"
-                                                        ],
-                                                        "borderColor": COLORS[
-                                                            "primary"
-                                                        ],
-                                                        "borderRadius": "6px",
-                                                    },
-                                                ),
-                                                dcc.Download(id="download-metadata"),
-                                            ],
-                                        ),
-                                        html.Div(id="search-results-table"),
-                                        html.Div(
-                                            id="search-results-pagination",
-                                            className="mt-3 pagination-bar",
-                                            style={"display": "none"},
-                                            children=[
-                                                dbc.Button(
-                                                    [
-                                                        html.I(
-                                                            className="bi bi-arrow-left me-1"
-                                                        ),
-                                                        "Previous",
-                                                    ],
-                                                    id="search-page-prev",
-                                                    color="secondary",
-                                                    size="sm",
-                                                    disabled=True,
-                                                    style={"borderRadius": "6px"},
-                                                    className="me-3",
-                                                ),
-                                                html.Span(
-                                                    "Page 1 of 1",
-                                                    id="search-page-info",
-                                                    className="fw-semibold me-3",
-                                                ),
-                                                dbc.Button(
-                                                    [
-                                                        "Next",
-                                                        html.I(
-                                                            className="bi bi-arrow-right ms-1"
-                                                        ),
-                                                    ],
-                                                    id="search-page-next",
-                                                    color="secondary",
-                                                    size="sm",
-                                                    disabled=True,
-                                                    style={"borderRadius": "6px"},
-                                                ),
-                                            ],
-                                        ),
-                                    ],
-                                ),
-                                target_components={
-                                    "search-results-table": "children",
-                                    "search-results-pagination": "style",
-                                },
-                                delay_show=200,
-                                delay_hide=100,
-                            ),
-                            xs=12,
-                            sm=12,
-                            md=12,
-                            lg=9,
-                            style={"position": "relative", "zIndex": 10},
-                        ),
-                    ],
-                    className="py-4 g-4",
-                ),
-                dcc.Store(
-                    id="search-results-store",
-                    data={"results": [], "facets": {}, "query": "", "total": 0},
-                ),
-                dcc.Store(id="search-results-page", data=1),
             ],
             className="content-container",
         ),
@@ -1446,369 +662,44 @@ layout = html.Div(
 
 
 @callback(
-    Output("search-input", "value"),
-    Output("search-button", "n_clicks"),
+    Output("home-redirect", "href"),
+    Input("search-input", "value"),
+    Input("search-button", "n_clicks"),
     Input("search-example-1", "n_clicks"),
     Input("search-example-2", "n_clicks"),
     Input("search-example-3", "n_clicks"),
-    State("search-button", "n_clicks"),
+    State("search-mode-dropdown", "value"),
     prevent_initial_call=True,
 )
-def handle_search_examples(
-    example1_clicks, example2_clicks, example3_clicks, current_button_clicks
-):
-    """Handle clicks on search example links."""
+def redirect_search(query, search_clicks, ex1, ex2, ex3, mode):
+    """Redirect search to the targets or datasets browse page."""
     ctx = callback_context
     if not ctx.triggered:
-        return dash.no_update, dash.no_update
-
-    trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
-    current_clicks = current_button_clicks or 0
-
-    if trigger_id == "search-example-1":
-        return "SUMO1", current_clicks + 1
-    elif trigger_id == "search-example-2":
-        return "retina", current_clicks + 1
-    elif trigger_id == "search-example-3":
-        return "acute myeloid leukemia", current_clicks + 1
-
-    return dash.no_update, dash.no_update
-
-
-@callback(
-    Output("search-results-store", "data"),
-    Output("homepage-summary", "children", allow_duplicate=True),
-    Output("facet-filters", "style"),
-    Output("search-results-table", "children", allow_duplicate=True),
-    Input("search-input", "value"),
-    Input("search-button", "n_clicks"),
-    Input("search-mode-dropdown", "value"),
-    running=[
-        (Output("homepage-summary", "style"), {"display": "none"}, {}),
-    ],
-    prevent_initial_call="initial_duplicate",
-)
-def update_search_results(query, _, search_mode):
-    """Fetch fuzzy search results and store them."""
-    search_term = (query or "").strip() if query else ""
-    search_mode = search_mode or "targets"
-
-    summary_content = dash.no_update
-    filters_style = dash.no_update
-
-    if not search_term:
-        summary_data, error = get_landing_page_summary()
-        summary_content = _build_summary_component(summary_data, error)
-        filters_style = {
-            "display": "none",
-            "position": "relative",
-            "zIndex": 50,
-            "overflow": "visible",
-        }
-        return (
-            {
-                "results": [],
-                "facets": {},
-                "query": "",
-                "total": 0,
-                "page": 1,
-                "size": SEARCH_RESULTS_PAGE_SIZE,
-                "search_mode": search_mode,
-            },
-            summary_content,
-            filters_style,
-            [],  # Clear search results table
-        )
-
-    data = fetch_search_results(
-        query=search_term if search_term else None,
-        page=1,
-        size=SEARCH_RESULTS_PAGE_SIZE,
-        search_mode=search_mode,
-    )
-    results = data.get("results", [])
-    facets = data.get("facets", {})
-
-    store_payload = {
-        "results": results,
-        "facets": facets,
-        "query": search_term,
-        "total": data.get("total", len(results)),
-        "page": data.get("page", 1),
-        "size": data.get("size", SEARCH_RESULTS_PAGE_SIZE),
-        "total_pages": data.get("total_pages"),
-        "search_mode": search_mode,
-    }
-
-    summary_content = ""
-    filters_style = {
-        "position": "relative",
-        "zIndex": 50,
-        "overflow": "visible",
-        "display": "block",
-    }
-
-    return store_payload, summary_content, filters_style, []
-
-
-@callback(
-    Output("search-results-table", "children", allow_duplicate=True),
-    Output("search-results-pagination", "style"),
-    Output("search-page-info", "children"),
-    Output("search-page-prev", "disabled"),
-    Output("search-page-next", "disabled"),
-    Output("search-results-page", "data"),
-    Output("homepage-summary", "children", allow_duplicate=True),
-    Output("facet-filters", "children"),
-    Output("download-metadata-container", "style"),
-    Input("search-results-store", "data"),
-    Input({"type": "facet-filter", "field": ALL}, "value"),
-    Input("search-page-prev", "n_clicks"),
-    Input("search-page-next", "n_clicks"),
-    State({"type": "facet-filter", "field": ALL}, "id"),
-    State("search-results-page", "data"),
-    prevent_initial_call="initial_duplicate",
-)
-def render_filtered_results(
-    store_data, selected_values, prev_clicks, next_clicks, filter_ids, current_page
-):
-    """Render the results table and pagination based on search data and selected filters."""
-    ctx = callback_context
-    trigger = ctx.triggered[0]["prop_id"] if ctx.triggered else None
-
-    if not store_data or not store_data.get("query"):
-        return (
-            "",
-            {"display": "none"},
-            "Page 1 of 1",
-            True,
-            True,
-            1,
-            dash.no_update,
-            html.Div(),
-            {"display": "none"},
-        )
-
-    selected_filters = {}
-    if selected_values and filter_ids:
-        for values, filter_id in zip(selected_values, filter_ids):
-            if values:
-                cleaned = [str(v).strip() for v in values if v not in (None, "")]
-                if cleaned:
-                    selected_filters[filter_id["field"]] = cleaned
-
-    query = store_data.get("query")
-
-    if not query:
-        return (
-            "",
-            {"display": "none"},
-            "Page 1 of 1",
-            True,
-            True,
-            1,
-            dash.no_update,
-            html.Div(),
-            {"display": "none"},
-        )
-
-    # Determine search mode
-    search_mode = store_data.get("search_mode", "targets")
-    is_dataset_mode = search_mode == "datasets"
-
-    # Always use stored results for search queries - filter client-side
-    all_results = store_data.get("results", [])
-    original_facets = store_data.get("facets", {})
-
-    # Apply client-side filtering
-    def matches_filters(result, filters):
-        for field, selected_values in filters.items():
-            if not selected_values:
-                continue
-            # For dataset mode, map canonical target field names to dataset field names
-            actual_field = TARGET_TO_DATASET_FIELD.get(field, field) if is_dataset_mode else field
-            result_value = result.get(actual_field)
-            if result_value is None:
-                return False
-            # Handle both list and scalar values
-            if isinstance(result_value, list):
-                if not any(v in selected_values for v in result_value):
-                    return False
-            else:
-                if result_value not in selected_values:
-                    return False
-        return True
-
-    if selected_filters:
-        filtered_results = [r for r in all_results if matches_filters(r, selected_filters)]
-    else:
-        filtered_results = all_results
-
-    # Recalculate facet counts based on filtered results
-    if selected_filters:
-        facets = _recalculate_facets(filtered_results, original_facets, search_mode)
-    else:
-        facets = original_facets
-
-    # Pagination: 10 records per page
-    page_size = 10
-    total_results = len(filtered_results)
-    total_pages = max(1, (total_results + page_size - 1) // page_size)
-
-    # Handle page navigation
-    triggered_prop = trigger or ""
-    current_page_number = current_page or 1
-
-    if "search-results-store" in triggered_prop or "facet-filter" in triggered_prop:
-        # Reset to page 1 on new search or filter change
-        current_page_number = 1
-    elif "search-page-prev" in triggered_prop:
-        current_page_number = max(1, current_page_number - 1)
-    elif "search-page-next" in triggered_prop:
-        current_page_number = min(total_pages, current_page_number + 1)
-
-    # Ensure page is within bounds
-    if current_page_number > total_pages:
-        current_page_number = total_pages
-    if current_page_number < 1:
-        current_page_number = 1
-
-    # Slice results for current page
-    start_idx = (current_page_number - 1) * page_size
-    end_idx = start_idx + page_size
-    results = filtered_results[start_idx:end_idx]
-
-    if not results and total_results == 0:
-        filters_children = _build_filter_controls(facets, selected_filters, FACET_FIELDS, search_mode)
-        no_results_msg = "No datasets found. Try another search term." if is_dataset_mode else "No results found. Try another target name."
-        return (
-            dbc.Alert(
-                [
-                    html.I(className="bi bi-info-circle me-2"),
-                    no_results_msg,
-                ],
-                color="info",
-                className="shadow-sm",
-                style={"borderRadius": "10px"},
-            ),
-            {"display": "none"},
-            f"Page 1 of {total_pages} ({total_results} results)",
-            True,
-            True,
-            current_page_number,
-            "",
-            filters_children,
-            {"display": "none"},
-        )
-
-    if is_dataset_mode:
-        table = _render_dataset_search_results(results)
-    else:
-        table = _render_search_results(results)
-    filters_children = _build_filter_controls(facets, selected_filters, FACET_FIELDS, search_mode)
-
-    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
-    page_info = f"Page {current_page_number} of {total_pages} ({total_results} results)"
-    prev_disabled = current_page_number <= 1
-    next_disabled = current_page_number >= total_pages
-
-    return (
-        table,
-        pagination_style,
-        page_info,
-        prev_disabled,
-        next_disabled,
-        current_page_number,
-        "",
-        filters_children,
-        {"display": "flex", "justifyContent": "flex-end"},
-    )
-
-
-@callback(
-    Output("download-metadata", "data"),
-    Input("download-metadata-btn", "n_clicks"),
-    State("search-results-store", "data"),
-    State({"type": "facet-filter", "field": ALL}, "value"),
-    State({"type": "facet-filter", "field": ALL}, "id"),
-    prevent_initial_call=True,
-)
-def download_metadata(n_clicks, store_data, selected_values, filter_ids):
-    """Download all search results as CSV when the button is clicked."""
-    if not n_clicks or not store_data or not store_data.get("query"):
         return dash.no_update
 
-    query = store_data.get("query")
-    search_mode = store_data.get("search_mode", "targets")
+    trigger = ctx.triggered[0]["prop_id"].split(".")[0]
 
-    # Build filters from current selection
-    selected_filters = {}
-    if selected_values and filter_ids:
-        for values, filter_id in zip(selected_values, filter_ids):
-            if values:
-                cleaned = [str(v).strip() for v in values if v not in (None, "")]
-                if cleaned:
-                    selected_filters[filter_id["field"]] = cleaned
+    if trigger == "search-example-1":
+        query = "SUMO1"
+    elif trigger == "search-example-2":
+        query = "retina"
+    elif trigger == "search-example-3":
+        query = "acute myeloid leukemia"
 
-    # Fetch all results by paginating through the API
-    all_results = fetch_all_search_results(
-        query=query,
-        filters=selected_filters or None,
-        search_mode=search_mode,
-    )
-
-    if not all_results:
+    if not query or not query.strip():
         return dash.no_update
 
-    # Define columns to include in the CSV based on search mode
-    if search_mode == "datasets":
-        columns = [
-            "dataset_id",
-            "study_title",
-            "study_year",
-            "data_modalities",
-        ]
-    else:
-        columns = [
-            "perturbed_target_symbol",
-            "n_experiments",
-            "n_sig_perturb_pairs_up",
-            "n_sig_perturb_pairs_down",
-            "n_sig_crispr",
-            "n_mave",
-            "top_gsea_terms",
-            "data_modalities",
-            "tissues_tested",
-            "cell_types_tested",
-            "cell_lines_tested",
-            "sex_tested",
-            "developmental_stages_tested",
-            "diseases_tested",
-            "license",
-        ]
+    mode = mode or "targets"
+    page = "targets" if mode == "targets" else "datasets"
+    return f"/perturbation-catalogue/{page}?q={quote(query.strip())}"
 
-    # Build CSV content
-    csv_lines = [",".join(columns)]
-    for record in all_results:
-        row_values = []
-        for col in columns:
-            value = record.get(col, "")
-            if isinstance(value, list):
-                value = "; ".join(str(v) for v in value)
-            elif value is None:
-                value = ""
-            else:
-                value = str(value)
-            # Escape quotes and wrap in quotes if contains comma or quote
-            if "," in value or '"' in value or "\n" in value:
-                value = '"' + value.replace('"', '""') + '"'
-            row_values.append(value)
-        csv_lines.append(",".join(row_values))
 
-    csv_content = "\n".join(csv_lines)
-
-    # Generate filename with query and search mode
-    safe_query = "".join(c if c.isalnum() or c in "-_" else "_" for c in query[:30])
-    filename = f"perturbation_catalogue_{search_mode}_{safe_query}.csv"
-
-    return dict(content=csv_content, filename=filename, type="text/csv")
+@callback(
+    Output("homepage-summary", "children"),
+    Input("home-redirect", "href"),
+    prevent_initial_call=False,
+)
+def load_summary(_):
+    """Load the summary dashboard on page mount."""
+    summary_data, error = get_landing_page_summary()
+    return _build_summary_component(summary_data, error)

--- a/fe/pages/targets.py
+++ b/fe/pages/targets.py
@@ -1,0 +1,620 @@
+"""Browse targets page for Perturbation Catalogue."""
+
+import dash
+from dash import dcc, html, Input, Output, State, callback, ALL, callback_context
+import dash_bootstrap_components as dbc
+from urllib.parse import parse_qs
+from utils import (
+    COLORS,
+    FACET_FIELDS,
+    fetch_search_results,
+    fetch_all_search_results,
+)
+from components.search_table import (
+    TARGET_TO_DATASET_FIELD,
+    render_targets_table,
+    recalculate_facets,
+    filter_placeholder,
+    build_filter_controls,
+)
+
+dash.register_page(__name__, path="/targets", name="Targets", title="Browse Targets")
+
+PAGE_SIZE = 10
+
+
+layout = html.Div(
+    [
+        dcc.Location(id="targets-url", refresh=False),
+        dbc.Container(
+            [
+                html.Div(
+                    [
+                        html.H2("Browse Targets", className="mb-3 mt-4"),
+                        html.P(
+                            "Explore all gene targets across perturbation experiments. Use the search bar to filter by gene name or metadata, and the facets to narrow down results.",
+                            className="text-muted mb-3",
+                        ),
+                        dbc.InputGroup(
+                            [
+                                dbc.Input(
+                                    id="targets-search-input",
+                                    placeholder="Search targets by gene name, tissue, disease...",
+                                    type="text",
+                                    value="",
+                                    debounce=True,
+                                    className="form-control-lg",
+                                    style={"borderRadius": "8px 0 0 8px"},
+                                ),
+                                dbc.Button(
+                                    [
+                                        html.I(className="bi bi-search me-2"),
+                                        "Search",
+                                    ],
+                                    id="targets-search-button",
+                                    color="primary",
+                                    n_clicks=0,
+                                    className="btn-lg",
+                                    style={
+                                        "backgroundColor": COLORS["primary"],
+                                        "borderColor": COLORS["primary"],
+                                        "borderRadius": "0 8px 8px 0",
+                                        "paddingLeft": "2rem",
+                                        "paddingRight": "2rem",
+                                    },
+                                ),
+                            ],
+                            className="mb-4",
+                            style={"maxWidth": "700px"},
+                        ),
+                    ]
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.Div(
+                                id="targets-facets",
+                                className="mt-2",
+                                style={
+                                    "position": "relative",
+                                    "zIndex": 50,
+                                    "overflow": "visible",
+                                },
+                            ),
+                            xs=12,
+                            sm=12,
+                            md=12,
+                            lg=3,
+                            className="mb-4",
+                            style={
+                                "overflow": "visible",
+                                "position": "relative",
+                                "zIndex": 50,
+                            },
+                        ),
+                        dbc.Col(
+                            dcc.Loading(
+                                id="targets-results-loading",
+                                type="circle",
+                                color=COLORS["primary"],
+                                children=html.Div(
+                                    id="targets-results",
+                                    className="mt-2",
+                                    children=[
+                                        html.Div(
+                                            id="targets-download-container",
+                                            className="mb-3",
+                                            style={"display": "none"},
+                                            children=[
+                                                dbc.Button(
+                                                    [
+                                                        html.I(
+                                                            className="bi bi-download me-2"
+                                                        ),
+                                                        "Download Metadata",
+                                                    ],
+                                                    id="targets-download-btn",
+                                                    color="primary",
+                                                    size="sm",
+                                                    style={
+                                                        "backgroundColor": COLORS[
+                                                            "primary"
+                                                        ],
+                                                        "borderColor": COLORS[
+                                                            "primary"
+                                                        ],
+                                                        "borderRadius": "6px",
+                                                    },
+                                                ),
+                                                dcc.Download(id="targets-download"),
+                                            ],
+                                        ),
+                                        html.Div(id="targets-results-table"),
+                                        html.Div(
+                                            id="targets-pagination",
+                                            className="mt-3 pagination-bar",
+                                            style={"display": "none"},
+                                            children=[
+                                                dbc.Button(
+                                                    [
+                                                        html.I(
+                                                            className="bi bi-arrow-left me-1"
+                                                        ),
+                                                        "Previous",
+                                                    ],
+                                                    id="targets-page-prev",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    disabled=True,
+                                                    style={"borderRadius": "6px"},
+                                                    className="me-3",
+                                                ),
+                                                html.Span(
+                                                    "Page 1 of 1",
+                                                    id="targets-page-info",
+                                                    className="fw-semibold me-3",
+                                                ),
+                                                dbc.Button(
+                                                    [
+                                                        "Next",
+                                                        html.I(
+                                                            className="bi bi-arrow-right ms-1"
+                                                        ),
+                                                    ],
+                                                    id="targets-page-next",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    disabled=True,
+                                                    style={"borderRadius": "6px"},
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                                target_components={
+                                    "targets-results-table": "children",
+                                    "targets-pagination": "style",
+                                },
+                                delay_show=200,
+                                delay_hide=100,
+                            ),
+                            xs=12,
+                            sm=12,
+                            md=12,
+                            lg=9,
+                            style={"position": "relative", "zIndex": 10},
+                        ),
+                    ],
+                    className="py-2 g-4",
+                ),
+                dcc.Store(
+                    id="targets-results-store",
+                    data={
+                        "results": [],
+                        "facets": {},
+                        "query": "",
+                        "total": 0,
+                        "total_pages": 0,
+                        "current_page": 1,
+                        "server_paginated": True,
+                    },
+                ),
+                dcc.Store(id="targets-page-store", data=1),
+            ],
+            className="content-container",
+        ),
+    ]
+)
+
+
+@callback(
+    Output("targets-search-input", "value"),
+    Input("targets-url", "search"),
+)
+def populate_search_from_url(search):
+    """Populate search input from URL query parameter on initial load."""
+    if search:
+        params = parse_qs(search.lstrip("?"))
+        query = params.get("q", [None])[0]
+        if query:
+            return query[:500]
+    return ""
+
+
+@callback(
+    Output("targets-results-store", "data"),
+    Input("targets-search-input", "value"),
+    Input("targets-search-button", "n_clicks"),
+)
+def load_targets_data(query, _n_clicks):
+    """Fetch target search results from backend."""
+    search_term = (query or "").strip() if query else ""
+
+    if search_term:
+        # Client-side mode: fetch all matches (backend returns up to 1000)
+        data = fetch_search_results(
+            query=search_term,
+            page=1,
+            size=100,
+            search_mode="targets",
+        )
+        return {
+            "results": data.get("results", []),
+            "facets": data.get("facets", {}),
+            "query": search_term,
+            "total": data.get("total", 0),
+            "total_pages": 1,
+            "current_page": 1,
+            "server_paginated": False,
+        }
+    else:
+        # Server-side mode: fetch first page only
+        data = fetch_search_results(
+            query=None,
+            page=1,
+            size=PAGE_SIZE,
+            search_mode="targets",
+        )
+        return {
+            "results": data.get("results", []),
+            "facets": data.get("facets", {}),
+            "query": "",
+            "total": data.get("total", 0),
+            "total_pages": data.get("total_pages", 0),
+            "current_page": 1,
+            "server_paginated": True,
+        }
+
+
+@callback(
+    Output("targets-results-table", "children"),
+    Output("targets-pagination", "style"),
+    Output("targets-page-info", "children"),
+    Output("targets-page-prev", "disabled"),
+    Output("targets-page-next", "disabled"),
+    Output("targets-page-store", "data"),
+    Output("targets-facets", "children"),
+    Output("targets-download-container", "style"),
+    Input("targets-results-store", "data"),
+    Input({"type": "targets-facet-filter", "field": ALL}, "value"),
+    Input("targets-page-prev", "n_clicks"),
+    Input("targets-page-next", "n_clicks"),
+    State({"type": "targets-facet-filter", "field": ALL}, "id"),
+    State("targets-page-store", "data"),
+)
+def render_targets_results(
+    store_data, selected_values, prev_clicks, next_clicks, filter_ids, current_page
+):
+    """Render target results with server-side or client-side filtering and pagination."""
+    ctx = callback_context
+    trigger = ctx.triggered[0]["prop_id"] if ctx.triggered else None
+
+    if not store_data or not store_data.get("results"):
+        # Check if this is server-paginated mode with no results yet (initial load)
+        is_server = store_data.get("server_paginated", False) if store_data else False
+        if is_server and store_data and store_data.get("total", 0) == 0:
+            # Genuinely no results in browse mode
+            pass
+        return (
+            filter_placeholder("No targets found. Try a search query."),
+            {"display": "none"},
+            "Page 1 of 1",
+            True,
+            True,
+            1,
+            filter_placeholder("Search to see available filters."),
+            {"display": "none"},
+        )
+
+    # Build selected filters dict
+    selected_filters = {}
+    if selected_values and filter_ids:
+        for values, filter_id in zip(selected_values, filter_ids):
+            if values:
+                cleaned = [str(v).strip() for v in values if v not in (None, "")]
+                if cleaned:
+                    selected_filters[filter_id["field"]] = cleaned
+
+    server_paginated = store_data.get("server_paginated", False)
+    triggered_prop = trigger or ""
+
+    if server_paginated:
+        # --- SERVER-SIDE PAGINATION MODE ---
+        return _render_server_side(
+            store_data, selected_filters, triggered_prop, current_page
+        )
+    else:
+        # --- CLIENT-SIDE FILTERING MODE ---
+        return _render_client_side(
+            store_data, selected_filters, triggered_prop, current_page
+        )
+
+
+def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
+    """Handle rendering in server-side pagination mode (no query)."""
+    current_page_number = store_data.get("current_page", 1) or 1
+
+    if "targets-results-store" in triggered_prop:
+        # Initial load or new search: use data from store directly
+        results = store_data.get("results", [])
+        facets = store_data.get("facets", {})
+        total = store_data.get("total", 0)
+        total_pages = store_data.get("total_pages", 0)
+        current_page_number = store_data.get("current_page", 1)
+    elif "targets-page-prev" in triggered_prop:
+        current_page_number = max(1, (current_page or 1) - 1)
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=current_page_number,
+            size=PAGE_SIZE,
+            search_mode="targets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    elif "targets-page-next" in triggered_prop:
+        old_total_pages = store_data.get("total_pages", 1)
+        current_page_number = min(old_total_pages, (current_page or 1) + 1)
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=current_page_number,
+            size=PAGE_SIZE,
+            search_mode="targets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    elif "facet-filter" in triggered_prop:
+        # Facet changed: reset to page 1 with new filters
+        current_page_number = 1
+        data = fetch_search_results(
+            query=None,
+            filters=selected_filters or None,
+            page=1,
+            size=PAGE_SIZE,
+            search_mode="targets",
+        )
+        results = data.get("results", [])
+        facets = data.get("facets", {})
+        total = data.get("total", 0)
+        total_pages = data.get("total_pages", 0)
+    else:
+        # Fallback: use store data
+        results = store_data.get("results", [])
+        facets = store_data.get("facets", {})
+        total = store_data.get("total", 0)
+        total_pages = store_data.get("total_pages", 0)
+        current_page_number = store_data.get("current_page", 1)
+
+    total_pages = max(1, total_pages)
+    if current_page_number > total_pages:
+        current_page_number = total_pages
+    if current_page_number < 1:
+        current_page_number = 1
+
+    if not results and total == 0:
+        filters_children = build_filter_controls(
+            facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
+        )
+        return (
+            dbc.Alert(
+                [
+                    html.I(className="bi bi-info-circle me-2"),
+                    "No targets found matching your filters.",
+                ],
+                color="info",
+                className="shadow-sm",
+                style={"borderRadius": "10px"},
+            ),
+            {"display": "none"},
+            f"Page 1 of 1 ({total} results)",
+            True,
+            True,
+            current_page_number,
+            filters_children,
+            {"display": "none"},
+        )
+
+    table = render_targets_table(results)
+    filters_children = build_filter_controls(
+        facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
+    )
+
+    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
+    page_info = f"Page {current_page_number} of {total_pages} ({total} results)"
+    prev_disabled = current_page_number <= 1
+    next_disabled = current_page_number >= total_pages
+
+    return (
+        table,
+        pagination_style,
+        page_info,
+        prev_disabled,
+        next_disabled,
+        current_page_number,
+        filters_children,
+        {"display": "flex", "justifyContent": "flex-end"},
+    )
+
+
+def _render_client_side(store_data, selected_filters, triggered_prop, current_page):
+    """Handle rendering in client-side filtering mode (with query)."""
+    all_results = store_data.get("results", [])
+    original_facets = store_data.get("facets", {})
+
+    # Apply client-side filtering
+    def matches_filters(result, filters):
+        for field, sel_values in filters.items():
+            if not sel_values:
+                continue
+            result_value = result.get(field)
+            if result_value is None:
+                return False
+            if isinstance(result_value, list):
+                if not any(v in sel_values for v in result_value):
+                    return False
+            else:
+                if result_value not in sel_values:
+                    return False
+        return True
+
+    if selected_filters:
+        filtered_results = [
+            r for r in all_results if matches_filters(r, selected_filters)
+        ]
+    else:
+        filtered_results = all_results
+
+    # Recalculate facet counts
+    if selected_filters:
+        facets = recalculate_facets(filtered_results, original_facets, "targets")
+    else:
+        facets = original_facets
+
+    # Pagination
+    total_results = len(filtered_results)
+    total_pages = max(1, (total_results + PAGE_SIZE - 1) // PAGE_SIZE)
+
+    current_page_number = current_page or 1
+
+    if "targets-results-store" in triggered_prop or "facet-filter" in triggered_prop:
+        current_page_number = 1
+    elif "targets-page-prev" in triggered_prop:
+        current_page_number = max(1, current_page_number - 1)
+    elif "targets-page-next" in triggered_prop:
+        current_page_number = min(total_pages, current_page_number + 1)
+
+    if current_page_number > total_pages:
+        current_page_number = total_pages
+    if current_page_number < 1:
+        current_page_number = 1
+
+    start_idx = (current_page_number - 1) * PAGE_SIZE
+    end_idx = start_idx + PAGE_SIZE
+    page_results = filtered_results[start_idx:end_idx]
+
+    if not page_results and total_results == 0:
+        filters_children = build_filter_controls(
+            facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
+        )
+        return (
+            dbc.Alert(
+                [
+                    html.I(className="bi bi-info-circle me-2"),
+                    "No targets found matching your filters.",
+                ],
+                color="info",
+                className="shadow-sm",
+                style={"borderRadius": "10px"},
+            ),
+            {"display": "none"},
+            f"Page 1 of {total_pages} ({total_results} results)",
+            True,
+            True,
+            current_page_number,
+            filters_children,
+            {"display": "none"},
+        )
+
+    table = render_targets_table(page_results)
+    filters_children = build_filter_controls(
+        facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
+    )
+
+    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
+    page_info = f"Page {current_page_number} of {total_pages} ({total_results} results)"
+    prev_disabled = current_page_number <= 1
+    next_disabled = current_page_number >= total_pages
+
+    return (
+        table,
+        pagination_style,
+        page_info,
+        prev_disabled,
+        next_disabled,
+        current_page_number,
+        filters_children,
+        {"display": "flex", "justifyContent": "flex-end"},
+    )
+
+
+@callback(
+    Output("targets-download", "data"),
+    Input("targets-download-btn", "n_clicks"),
+    State("targets-results-store", "data"),
+    State({"type": "targets-facet-filter", "field": ALL}, "value"),
+    State({"type": "targets-facet-filter", "field": ALL}, "id"),
+    prevent_initial_call=True,
+)
+def download_targets_metadata(n_clicks, store_data, selected_values, filter_ids):
+    """Download all target results as CSV."""
+    if not n_clicks or not store_data:
+        return dash.no_update
+
+    query = store_data.get("query")
+
+    selected_filters = {}
+    if selected_values and filter_ids:
+        for values, filter_id in zip(selected_values, filter_ids):
+            if values:
+                cleaned = [str(v).strip() for v in values if v not in (None, "")]
+                if cleaned:
+                    selected_filters[filter_id["field"]] = cleaned
+
+    all_results = fetch_all_search_results(
+        query=query if query else None,
+        filters=selected_filters or None,
+        search_mode="targets",
+    )
+
+    if not all_results:
+        return dash.no_update
+
+    columns = [
+        "perturbed_target_symbol",
+        "n_experiments",
+        "n_sig_perturb_pairs_up",
+        "n_sig_perturb_pairs_down",
+        "n_sig_crispr",
+        "n_mave",
+        "top_gsea_terms",
+        "data_modalities",
+        "tissues_tested",
+        "cell_types_tested",
+        "cell_lines_tested",
+        "sex_tested",
+        "developmental_stages_tested",
+        "diseases_tested",
+        "license",
+    ]
+
+    csv_lines = [",".join(columns)]
+    for record in all_results:
+        row_values = []
+        for col in columns:
+            value = record.get(col, "")
+            if isinstance(value, list):
+                value = "; ".join(str(v) for v in value)
+            elif value is None:
+                value = ""
+            else:
+                value = str(value)
+            # Sanitize formula injection characters
+            if value and value[0:1] in ("=", "+", "-", "@", "\t", "\r"):
+                value = "'" + value
+            if "," in value or '"' in value or "\n" in value:
+                value = '"' + value.replace('"', '""') + '"'
+            row_values.append(value)
+        csv_lines.append(",".join(row_values))
+
+    csv_content = "\n".join(csv_lines)
+    safe_query = "".join(
+        c if c.isalnum() or c in "-_" else "_" for c in (query or "all")[:30]
+    )
+    filename = f"perturbation_catalogue_targets_{safe_query}.csv"
+
+    return dict(content=csv_content, filename=filename, type="text/csv")


### PR DESCRIPTION
Users can now browse all targets and datasets without searching first. Two new pages (/targets, /datasets) provide faceted browsing with server-side pagination (10 per page), search, and CSV download. Home page search now redirects to these pages with query pre-filled.

Key design decisions:

  - Dual pagination mode: Without a search query, pages use server-side pagination (API fetches 10 results per page). With a search query, pages use client-side filtering (API returns all matches, paginated in browser)
  - Facet filters work in both modes: server-side triggers a new API call with filters; client-side filters in-memory
  - CSV download with formula injection sanitization
  - URL query param support (?q=BRCA2) for cross-page navigation from the home page
  - All component IDs are prefixed (targets-/datasets-) to avoid Dash callback collisions