### PR TITLE
Fix search/filtering bugs and streamline dataset details page

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -275,7 +275,7 @@ def build_elasticsearch_query(
 
 
 def build_aggregations(facet_fields: Optional[List[str]] = None) -> Dict[str, Any]:
-    """Build aggregations for all facet fields"""
+    """Build aggregations for all facet fields."""
     fields = facet_fields or FACET_FIELDS
     aggs = {}
     for field in fields:
@@ -387,37 +387,6 @@ def build_dataset_elasticsearch_query(
     return {"match_all": {}}
 
 
-def _calculate_facets_from_results(
-    results: List[Dict[str, Any]],
-    facet_fields: List[str],
-) -> Dict[str, List[FacetValue]]:
-    """Calculate facet counts from the returned results.
-
-    Used for search queries to ensure facets match the result set.
-    """
-    from collections import Counter
-
-    facets_dict = {}
-    for field in facet_fields:
-        counter: Counter = Counter()
-        for result in results:
-            value = result.get(field)
-            if value is None:
-                continue
-            if isinstance(value, list):
-                for v in value:
-                    if v:
-                        counter[v] += 1
-            elif value:
-                counter[value] += 1
-
-        facets_dict[field] = [
-            FacetValue(value=val, count=count)
-            for val, count in counter.most_common(100)
-        ]
-    return facets_dict
-
-
 def parse_filters_from_params(
     license: Optional[str] = None,
     data_modalities: Optional[str] = None,
@@ -505,19 +474,7 @@ async def perform_search(
 
     aggs = build_aggregations(facet_fields)
 
-    # For search queries, return all matching results so frontend can filter client-side
-    # For browsing (no query), use normal pagination
-    has_query = query and query.strip()
-    max_search_results = 1000  # Reasonable limit for search results
-
-    if has_query:
-        # Return all matching results (up to max) for client-side filtering
-        effective_size = max_search_results
-        from_ = 0
-    else:
-        # Normal pagination for browsing
-        effective_size = size
-        from_ = (page - 1) * size
+    from_ = (page - 1) * size
 
     # Execute search with aggregations
     try:
@@ -526,7 +483,7 @@ async def perform_search(
             query=es_query,
             aggs=aggs,
             from_=from_,
-            size=effective_size,
+            size=size,
         )
     except Exception as e:
         error_detail = str(e)
@@ -538,23 +495,37 @@ async def perform_search(
     hits = response.get("hits", {})
     results = [hit["_source"] for hit in hits.get("hits", [])]
 
-    if has_query:
-        # For search queries: calculate facets from returned results
-        total = len(results)
-        total_pages = 1  # All results returned in one response
-        facets_dict = _calculate_facets_from_results(results, facet_fields)
-    else:
-        # For browsing: use ES aggregations for full dataset facets
-        total = hits.get("total", {}).get("value", 0)
-        total_pages = (total + size - 1) // size if total > 0 else 0
-        aggregations = response.get("aggregations", {})
-        facets_dict = {}
-        for field in facet_fields:
-            buckets = aggregations.get(field, {}).get("buckets", [])
-            facets_dict[field] = [
-                FacetValue(value=bucket["key"], count=bucket["doc_count"])
-                for bucket in buckets
-            ]
+    total = hits.get("total", {}).get("value", 0)
+    total_pages = (total + size - 1) // size if total > 0 else 0
+    aggregations = response.get("aggregations", {})
+
+    # Build a lookup of lowercase → original-case values from result _source
+    # fields, so we can restore proper display case for aggregation keys
+    # (the lc_ascii normalizer lowercases all aggregation values).
+    original_case: Dict[str, Dict[str, str]] = {}
+    for field in facet_fields:
+        field_map: Dict[str, str] = {}
+        for result in results:
+            val = result.get(field)
+            if val is None:
+                continue
+            vals = val if isinstance(val, list) else [val]
+            for v in vals:
+                if v and isinstance(v, str):
+                    field_map.setdefault(v.lower(), v)
+        original_case[field] = field_map
+
+    facets_dict = {}
+    for field in facet_fields:
+        buckets = aggregations.get(field, {}).get("buckets", [])
+        case_map = original_case.get(field, {})
+        facets_dict[field] = [
+            FacetValue(
+                value=case_map.get(bucket["key"], bucket["key"]),
+                count=bucket["doc_count"],
+            )
+            for bucket in buckets
+        ]
 
     # Remap dataset field names to canonical target field names
     if is_dataset_mode:
@@ -567,7 +538,7 @@ async def perform_search(
     return SearchResponse(
         total=total,
         page=page,
-        size=len(results) if has_query else size,
+        size=size,
         total_pages=total_pages,
         results=results,
         facets=facets,
@@ -663,7 +634,8 @@ async def search_get(
         None, description="Comma-separated list of license labels (dataset mode)"
     ),
     library_perturbation_type_labels: Optional[str] = Query(
-        None, description="Comma-separated list of perturbation type labels (dataset mode)"
+        None,
+        description="Comma-separated list of perturbation type labels (dataset mode)",
     ),
     tissue_labels: Optional[str] = Query(
         None, description="Comma-separated list of tissue labels (dataset mode)"
@@ -678,7 +650,8 @@ async def search_get(
         None, description="Comma-separated list of sex labels (dataset mode)"
     ),
     developmental_stage_labels: Optional[str] = Query(
-        None, description="Comma-separated list of developmental stage labels (dataset mode)"
+        None,
+        description="Comma-separated list of developmental stage labels (dataset mode)",
     ),
     disease_labels: Optional[str] = Query(
         None, description="Comma-separated list of disease labels (dataset mode)"
@@ -717,7 +690,10 @@ async def search_post(request: SearchRequest):
     Accepts JSON body with search parameters.
     """
     return await perform_search(
-        request.query, request.filters, request.page, request.size,
+        request.query,
+        request.filters,
+        request.page,
+        request.size,
         getattr(request, "search_mode", "targets"),
     )
 

--- a/fe/assets/custom.css
+++ b/fe/assets/custom.css
@@ -176,9 +176,9 @@ body {
     color: #495057;
 }
 
-/* Smooth transitions */
-* {
-    transition: all 0.3s ease;
+/* Smooth transitions – only animate visual properties, not layout ones */
+.card, .btn, .form-control, .form-select {
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 /* Card hover effects */
@@ -370,13 +370,6 @@ body {
 
 .facet-controls {
     position: relative;
-    isolation: isolate;
-}
-
-.facet-controls .facet-filter-card {
-    position: relative;
-    overflow: visible !important;
-    z-index: 1;
 }
 
 .facet-controls .facet-filter-card .card-header {
@@ -385,46 +378,12 @@ body {
     font-weight: 600;
 }
 
-/* Stop hover lift (transforms) from creating a new stacking context */
+/* Prevent hover lift from creating a new stacking context on facet cards */
 .facet-controls .facet-filter-card.card:hover {
     transform: none !important;
     box-shadow: 0 4px 12px rgba(0,0,0,0.12);
 }
 
-/* Raise the active card while it's focused (dropdown open clicks focus the control) */
-.facet-controls .facet-filter-card:focus-within {
-    z-index: 5000;
-}
-
-.facet-controls .facet-filter-card:has(.facet-dropdown.is-open) {
-    z-index: 6500;
-}
-
 .facet-controls .facet-filter-card .card-body {
     overflow: visible;
-}
-
-/* Dropdown shell */
-.facet-controls .facet-dropdown {
-    position: relative;
-}
-
-/* When the dropdown is open, elevate its wrapper and ensure menu sits above siblings */
-.facet-controls .facet-dropdown.is-open {
-    z-index: 6000;
-}
-
-.facet-controls .facet-dropdown.is-open .Select-menu-outer {
-    z-index: 7000;
-}
-
-.facet-controls .facet-dropdown.is-open .Select-menu-outer,
-.facet-controls .facet-dropdown.is-open .Select-menu {
-    overflow: visible !important;
-}
-
-/* Global safety net so menus elsewhere aren't clipped */
-.Select-menu-outer {
-    position: relative;
-    z-index: 8000;
 }

--- a/fe/components/search_table.py
+++ b/fe/components/search_table.py
@@ -14,19 +14,6 @@ from utils import (
 
 SEARCH_RESULTS_PAGE_SIZE = 15
 
-# Mapping from canonical (target) field names to dataset index field names.
-# Used for client-side filtering of dataset results.
-TARGET_TO_DATASET_FIELD = {
-    "license": "license_labels",
-    "data_modalities": "data_modalities",
-    "tissues_tested": "tissue_labels",
-    "cell_types_tested": "cell_type_labels",
-    "cell_lines_tested": "cell_line_labels",
-    "sex_tested": "sex_labels",
-    "developmental_stages_tested": "developmental_stage_labels",
-    "diseases_tested": "disease_labels",
-}
-
 
 def format_count(value):
     """Format numeric counts for display, falling back to '0' when missing."""
@@ -389,48 +376,6 @@ def render_datasets_table(results):
     return table
 
 
-def recalculate_facets(filtered_results, original_facets, search_mode="targets"):
-    """Recalculate facet counts based on currently filtered results."""
-    is_dataset_mode = search_mode == "datasets"
-    recalculated = {}
-    for field in FACET_FIELDS:
-        value_counts = {}
-        result_field = (
-            TARGET_TO_DATASET_FIELD.get(field, field) if is_dataset_mode else field
-        )
-        for result in filtered_results:
-            field_value = result.get(result_field)
-            if field_value is None:
-                continue
-            if isinstance(field_value, list):
-                for v in field_value:
-                    v_str = str(v).strip()
-                    if v_str:
-                        value_counts[v_str] = value_counts.get(v_str, 0) + 1
-            else:
-                v_str = str(field_value).strip()
-                if v_str:
-                    value_counts[v_str] = value_counts.get(v_str, 0) + 1
-
-        original_values = original_facets.get(field, [])
-        facet_list = []
-        seen = set()
-        for item in original_values:
-            val = item.get("value")
-            if val is not None:
-                val_str = str(val).strip()
-                count = value_counts.get(val_str, 0)
-                facet_list.append({"value": val_str, "count": count})
-                seen.add(val_str)
-        for val_str, count in value_counts.items():
-            if val_str not in seen:
-                facet_list.append({"value": val_str, "count": count})
-
-        recalculated[field] = facet_list
-
-    return recalculated
-
-
 def filter_placeholder(message="Search to enable filters."):
     """Placeholder message when filters are unavailable."""
     return dbc.Alert(
@@ -555,7 +500,8 @@ def build_filter_controls(
     }
 
     controls = []
-    for field in facet_fields:
+    total_fields = len(facet_fields)
+    for idx, field in enumerate(facet_fields):
         values = facets.get(field, [])
         if not values:
             continue
@@ -690,7 +636,7 @@ def build_filter_controls(
                     "borderRadius": "12px",
                     "overflow": "visible",
                     "position": "relative",
-                    "zIndex": 1,
+                    "zIndex": total_fields - idx,
                 },
             )
         )

--- a/fe/pages/dataset.py
+++ b/fe/pages/dataset.py
@@ -405,41 +405,136 @@ def render_dataset(data: Optional[Dict[str, Any]]):
             # Standalone field
             standalone_fields[key] = value
 
-    # Build the field list
-    field_elements = []
+    # Define primary fields shown by default, in display order.
+    # study_uri is consumed by study_title link and hidden separately.
+    PRIMARY_STANDALONE_ORDER = [
+        "study_title",
+        "first_author",
+        "last_author",
+        "study_year",
+        "experiment_title",
+        "data_modalities",
+    ]
+    PRIMARY_GROUPED = {"perturbation_type"}
+    SKIP_STANDALONE = {"dataset_id", "max_ingested_at", "study_uri"}
 
-    # First, add standalone fields (excluding dataset_id which we show in the header)
-    for key, value in sorted(standalone_fields.items()):
-        if key not in ("dataset_id", "max_ingested_at"):
-            # Special handling for associated_datasets
-            if key == "associated_datasets":
-                field_elements.append(_create_associated_datasets_display(value))
-            # Special handling for timepoints - format ISO 8601 durations
-            elif key == "timepoints" and isinstance(value, list):
-                formatted_timepoints = _format_timepoints(value)
-                field_elements.append(_create_field_display(key, formatted_timepoints))
-            else:
-                field_elements.append(_create_field_display(key, value))
+    study_uri = standalone_fields.get("study_uri")
 
-    # Then, add grouped fields (those with _labels and potentially _ids)
-    for base_name in sorted(field_groups.keys()):
-        group = field_groups[base_name]
+    # Build primary fields in the specified order
+    primary_elements = []
+    for key in PRIMARY_STANDALONE_ORDER:
+        value = standalone_fields.get(key)
+        if value is None:
+            continue
+        if key == "study_title":
+            # Render as clickable link using study_uri
+            display_value = (
+                html.A(
+                    _format_value(value),
+                    href=study_uri,
+                    target="_blank",
+                    rel="noopener noreferrer",
+                    className="text-decoration-none",
+                    style={"color": COLORS["primary"]},
+                )
+                if study_uri
+                else html.Span(_format_value(value), className="text-muted")
+            )
+            primary_elements.append(
+                html.Div(
+                    [
+                        html.Dt("Study Title:", className="col-sm-4 fw-semibold"),
+                        html.Dd(display_value, className="col-sm-8"),
+                    ],
+                    className="row mb-3",
+                )
+            )
+        elif key == "data_modalities":
+            primary_elements.append(
+                html.Div(
+                    [
+                        html.Dt("Data Modality:", className="col-sm-4 fw-semibold"),
+                        html.Dd(
+                            html.Span(_format_value(value), className="text-muted"),
+                            className="col-sm-8",
+                        ),
+                    ],
+                    className="row mb-3",
+                )
+            )
+        else:
+            primary_elements.append(_create_field_display(key, value))
+
+    # Add primary grouped fields (perturbation_type)
+    for base_name in PRIMARY_GROUPED:
+        group = field_groups.get(base_name)
+        if not group:
+            continue
         labels = group.get("labels")
         ids = group.get("ids")
-        # Use _labels field name if labels exist, otherwise use _ids
         if labels is not None:
-            field_elements.append(
+            primary_elements.append(
                 _create_field_display(f"{base_name}_labels", labels, ids)
             )
         elif ids is not None:
-            # If only IDs exist, display them as standalone values
-            field_elements.append(
+            primary_elements.append(
                 _create_field_display(f"{base_name}_ids", ids, None)
             )
 
-    # Build metadata section
-    metadata_section = html.Dl(
-        field_elements,
+    # Build secondary fields (everything else)
+    primary_standalone_set = set(PRIMARY_STANDALONE_ORDER)
+    secondary_elements = []
+
+    for key, value in sorted(standalone_fields.items()):
+        if key in SKIP_STANDALONE or key in primary_standalone_set:
+            continue
+        if key == "associated_datasets":
+            secondary_elements.append(_create_associated_datasets_display(value))
+        elif key == "timepoints" and isinstance(value, list):
+            formatted_timepoints = _format_timepoints(value)
+            secondary_elements.append(_create_field_display(key, formatted_timepoints))
+        else:
+            secondary_elements.append(_create_field_display(key, value))
+
+    for base_name in sorted(field_groups.keys()):
+        if base_name in PRIMARY_GROUPED:
+            continue
+        group = field_groups[base_name]
+        labels = group.get("labels")
+        ids = group.get("ids")
+        if labels is not None:
+            secondary_elements.append(
+                _create_field_display(f"{base_name}_labels", labels, ids)
+            )
+        elif ids is not None:
+            secondary_elements.append(
+                _create_field_display(f"{base_name}_ids", ids, None)
+            )
+
+    # Build metadata section: primary fields + collapsible secondary
+    metadata_children = [html.Dl(primary_elements)]
+    if secondary_elements:
+        metadata_children.append(
+            html.Details(
+                [
+                    html.Summary(
+                        "Other Metadata Fields",
+                        className="fw-semibold",
+                        style={
+                            "cursor": "pointer",
+                            "color": COLORS["primary"],
+                            "fontSize": "1.1rem",
+                            "padding": "0.5rem 0",
+                        },
+                    ),
+                    html.Dl(secondary_elements, className="mt-3"),
+                ],
+                className="mt-2",
+            )
+        )
+
+    metadata_section = html.Div(
+        metadata_children,
         className="mt-4",
         style={"maxWidth": "900px", "margin": "0 auto"},
     )
@@ -596,7 +691,6 @@ def render_dataset(data: Optional[Dict[str, Any]]):
             html.Hr(className="my-4"),
             html.H2(
                 "Data",
-                id="data-section-anchor",
                 className="fw-bold mb-3 text-center",
                 style={"color": COLORS["primary"]},
             ),
@@ -632,33 +726,10 @@ def render_dataset(data: Optional[Dict[str, Any]]):
             "crispr_perturbation_gene_search": "",
         }
 
-    # Build header with optional "Data" button
-    header_children = [
-        # Empty spacer for balance when button is shown
-        html.Div(style={"width": "100px"}) if modality else None,
-        html.H1(
-            f"Dataset: {formatted_dataset_id}",
-            className="display-5 fw-bold mb-0",
-            style={"color": COLORS["primary"]},
-        ),
-        html.A(
-            dbc.Button(
-                ["Data ", html.Span("↓", style={"fontSize": "0.8em"})],
-                color="primary",
-                size="sm",
-                className="shadow",
-            ),
-            href="#data-section-anchor",
-            className="align-self-center text-decoration-none",
-        ) if modality else html.Div(style={"width": "100px"}),
-    ]
-    # Filter out None values
-    header_children = [child for child in header_children if child is not None]
-
-    header_section = html.Div(
-        header_children,
-        className="d-flex justify-content-between align-items-center mb-4",
-        style={"maxWidth": "1200px", "margin": "0 auto"},
+    header_section = html.H1(
+        f"Dataset: {formatted_dataset_id}",
+        className="display-5 fw-bold mb-4 text-center",
+        style={"color": COLORS["primary"]},
     )
 
     # Hidden inputs for no-modality case (needed for callback)

--- a/fe/pages/datasets.py
+++ b/fe/pages/datasets.py
@@ -11,9 +11,7 @@ from utils import (
     fetch_all_search_results,
 )
 from components.search_table import (
-    TARGET_TO_DATASET_FIELD,
     render_datasets_table,
-    recalculate_facets,
     filter_placeholder,
     build_filter_controls,
 )
@@ -196,7 +194,6 @@ layout = html.Div(
                         "total": 0,
                         "total_pages": 0,
                         "current_page": 1,
-                        "server_paginated": True,
                     },
                 ),
                 dcc.Store(id="datasets-page-store", data=1),
@@ -230,40 +227,20 @@ def load_datasets_data(query, _n_clicks):
     """Fetch dataset search results from backend."""
     search_term = (query or "").strip() if query else ""
 
-    if search_term:
-        # Client-side mode: fetch all matches (backend returns up to 1000)
-        data = fetch_search_results(
-            query=search_term,
-            page=1,
-            size=100,
-            search_mode="datasets",
-        )
-        return {
-            "results": data.get("results", []),
-            "facets": data.get("facets", {}),
-            "query": search_term,
-            "total": data.get("total", 0),
-            "total_pages": 1,
-            "current_page": 1,
-            "server_paginated": False,
-        }
-    else:
-        # Server-side mode: fetch first page only
-        data = fetch_search_results(
-            query=None,
-            page=1,
-            size=PAGE_SIZE,
-            search_mode="datasets",
-        )
-        return {
-            "results": data.get("results", []),
-            "facets": data.get("facets", {}),
-            "query": "",
-            "total": data.get("total", 0),
-            "total_pages": data.get("total_pages", 0),
-            "current_page": 1,
-            "server_paginated": True,
-        }
+    data = fetch_search_results(
+        query=search_term or None,
+        page=1,
+        size=PAGE_SIZE,
+        search_mode="datasets",
+    )
+    return {
+        "results": data.get("results", []),
+        "facets": data.get("facets", {}),
+        "query": search_term,
+        "total": data.get("total", 0),
+        "total_pages": data.get("total_pages", 0),
+        "current_page": 1,
+    }
 
 
 @callback(
@@ -310,36 +287,45 @@ def render_datasets_results(
                 if cleaned:
                     selected_filters[filter_id["field"]] = cleaned
 
-    server_paginated = store_data.get("server_paginated", False)
     triggered_prop = trigger or ""
 
-    if server_paginated:
-        # --- SERVER-SIDE PAGINATION MODE ---
-        return _render_server_side(
-            store_data, selected_filters, triggered_prop, current_page
-        )
-    else:
-        # --- CLIENT-SIDE FILTERING MODE ---
-        return _render_client_side(
-            store_data, selected_filters, triggered_prop, current_page
-        )
+    return _render_server_side(
+        store_data, selected_filters, triggered_prop, current_page
+    )
 
 
 def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering in server-side pagination mode (no query)."""
+    """Handle rendering with server-side pagination and filtering."""
     current_page_number = store_data.get("current_page", 1) or 1
+    query = store_data.get("query") or None
 
     if "datasets-results-store" in triggered_prop:
-        # Initial load or new search: use data from store directly
-        results = store_data.get("results", [])
-        facets = store_data.get("facets", {})
-        total = store_data.get("total", 0)
-        total_pages = store_data.get("total_pages", 0)
-        current_page_number = store_data.get("current_page", 1)
+        # New search or initial load
+        if selected_filters:
+            # Active filters: re-fetch with both query and filters
+            current_page_number = 1
+            data = fetch_search_results(
+                query=query,
+                filters=selected_filters,
+                page=1,
+                size=PAGE_SIZE,
+                search_mode="datasets",
+            )
+            results = data.get("results", [])
+            facets = data.get("facets", {})
+            total = data.get("total", 0)
+            total_pages = data.get("total_pages", 0)
+        else:
+            # No filters: use store data directly
+            results = store_data.get("results", [])
+            facets = store_data.get("facets", {})
+            total = store_data.get("total", 0)
+            total_pages = store_data.get("total_pages", 0)
+            current_page_number = store_data.get("current_page", 1)
     elif "datasets-page-prev" in triggered_prop:
         current_page_number = max(1, (current_page or 1) - 1)
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
@@ -353,7 +339,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         old_total_pages = store_data.get("total_pages", 1)
         current_page_number = min(old_total_pages, (current_page or 1) + 1)
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
@@ -367,7 +353,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         # Facet changed: reset to page 1 with new filters
         current_page_number = 1
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=1,
             size=PAGE_SIZE,
@@ -421,108 +407,6 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
 
     pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
     page_info = f"Page {current_page_number} of {total_pages} ({total} results)"
-    prev_disabled = current_page_number <= 1
-    next_disabled = current_page_number >= total_pages
-
-    return (
-        table,
-        pagination_style,
-        page_info,
-        prev_disabled,
-        next_disabled,
-        current_page_number,
-        filters_children,
-        {"display": "flex", "justifyContent": "flex-end"},
-    )
-
-
-def _render_client_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering in client-side filtering mode (with query)."""
-    all_results = store_data.get("results", [])
-    original_facets = store_data.get("facets", {})
-
-    # Apply client-side filtering
-    def matches_filters(result, filters):
-        for field, sel_values in filters.items():
-            if not sel_values:
-                continue
-            actual_field = TARGET_TO_DATASET_FIELD.get(field, field)
-            result_value = result.get(actual_field)
-            if result_value is None:
-                return False
-            if isinstance(result_value, list):
-                if not any(v in sel_values for v in result_value):
-                    return False
-            else:
-                if result_value not in sel_values:
-                    return False
-        return True
-
-    if selected_filters:
-        filtered_results = [
-            r for r in all_results if matches_filters(r, selected_filters)
-        ]
-    else:
-        filtered_results = all_results
-
-    # Recalculate facet counts
-    if selected_filters:
-        facets = recalculate_facets(filtered_results, original_facets, "datasets")
-    else:
-        facets = original_facets
-
-    # Pagination
-    total_results = len(filtered_results)
-    total_pages = max(1, (total_results + PAGE_SIZE - 1) // PAGE_SIZE)
-
-    current_page_number = current_page or 1
-
-    if "datasets-results-store" in triggered_prop or "facet-filter" in triggered_prop:
-        current_page_number = 1
-    elif "datasets-page-prev" in triggered_prop:
-        current_page_number = max(1, current_page_number - 1)
-    elif "datasets-page-next" in triggered_prop:
-        current_page_number = min(total_pages, current_page_number + 1)
-
-    if current_page_number > total_pages:
-        current_page_number = total_pages
-    if current_page_number < 1:
-        current_page_number = 1
-
-    start_idx = (current_page_number - 1) * PAGE_SIZE
-    end_idx = start_idx + PAGE_SIZE
-    page_results = filtered_results[start_idx:end_idx]
-
-    if not page_results and total_results == 0:
-        filters_children = build_filter_controls(
-            facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
-        )
-        return (
-            dbc.Alert(
-                [
-                    html.I(className="bi bi-info-circle me-2"),
-                    "No datasets found matching your filters.",
-                ],
-                color="info",
-                className="shadow-sm",
-                style={"borderRadius": "10px"},
-            ),
-            {"display": "none"},
-            f"Page 1 of {total_pages} ({total_results} results)",
-            True,
-            True,
-            current_page_number,
-            filters_children,
-            {"display": "none"},
-        )
-
-    table = render_datasets_table(page_results)
-    filters_children = build_filter_controls(
-        facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
-    )
-
-    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
-    page_info = f"Page {current_page_number} of {total_pages} ({total_results} results)"
     prev_disabled = current_page_number <= 1
     next_disabled = current_page_number >= total_pages
 

--- a/fe/pages/targets.py
+++ b/fe/pages/targets.py
@@ -11,9 +11,7 @@ from utils import (
     fetch_all_search_results,
 )
 from components.search_table import (
-    TARGET_TO_DATASET_FIELD,
     render_targets_table,
-    recalculate_facets,
     filter_placeholder,
     build_filter_controls,
 )
@@ -196,7 +194,6 @@ layout = html.Div(
                         "total": 0,
                         "total_pages": 0,
                         "current_page": 1,
-                        "server_paginated": True,
                     },
                 ),
                 dcc.Store(id="targets-page-store", data=1),
@@ -230,40 +227,20 @@ def load_targets_data(query, _n_clicks):
     """Fetch target search results from backend."""
     search_term = (query or "").strip() if query else ""
 
-    if search_term:
-        # Client-side mode: fetch all matches (backend returns up to 1000)
-        data = fetch_search_results(
-            query=search_term,
-            page=1,
-            size=100,
-            search_mode="targets",
-        )
-        return {
-            "results": data.get("results", []),
-            "facets": data.get("facets", {}),
-            "query": search_term,
-            "total": data.get("total", 0),
-            "total_pages": 1,
-            "current_page": 1,
-            "server_paginated": False,
-        }
-    else:
-        # Server-side mode: fetch first page only
-        data = fetch_search_results(
-            query=None,
-            page=1,
-            size=PAGE_SIZE,
-            search_mode="targets",
-        )
-        return {
-            "results": data.get("results", []),
-            "facets": data.get("facets", {}),
-            "query": "",
-            "total": data.get("total", 0),
-            "total_pages": data.get("total_pages", 0),
-            "current_page": 1,
-            "server_paginated": True,
-        }
+    data = fetch_search_results(
+        query=search_term or None,
+        page=1,
+        size=PAGE_SIZE,
+        search_mode="targets",
+    )
+    return {
+        "results": data.get("results", []),
+        "facets": data.get("facets", {}),
+        "query": search_term,
+        "total": data.get("total", 0),
+        "total_pages": data.get("total_pages", 0),
+        "current_page": 1,
+    }
 
 
 @callback(
@@ -290,11 +267,6 @@ def render_targets_results(
     trigger = ctx.triggered[0]["prop_id"] if ctx.triggered else None
 
     if not store_data or not store_data.get("results"):
-        # Check if this is server-paginated mode with no results yet (initial load)
-        is_server = store_data.get("server_paginated", False) if store_data else False
-        if is_server and store_data and store_data.get("total", 0) == 0:
-            # Genuinely no results in browse mode
-            pass
         return (
             filter_placeholder("No targets found. Try a search query."),
             {"display": "none"},
@@ -315,36 +287,45 @@ def render_targets_results(
                 if cleaned:
                     selected_filters[filter_id["field"]] = cleaned
 
-    server_paginated = store_data.get("server_paginated", False)
     triggered_prop = trigger or ""
 
-    if server_paginated:
-        # --- SERVER-SIDE PAGINATION MODE ---
-        return _render_server_side(
-            store_data, selected_filters, triggered_prop, current_page
-        )
-    else:
-        # --- CLIENT-SIDE FILTERING MODE ---
-        return _render_client_side(
-            store_data, selected_filters, triggered_prop, current_page
-        )
+    return _render_server_side(
+        store_data, selected_filters, triggered_prop, current_page
+    )
 
 
 def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering in server-side pagination mode (no query)."""
+    """Handle rendering with server-side pagination and filtering."""
     current_page_number = store_data.get("current_page", 1) or 1
+    query = store_data.get("query") or None
 
     if "targets-results-store" in triggered_prop:
-        # Initial load or new search: use data from store directly
-        results = store_data.get("results", [])
-        facets = store_data.get("facets", {})
-        total = store_data.get("total", 0)
-        total_pages = store_data.get("total_pages", 0)
-        current_page_number = store_data.get("current_page", 1)
+        # New search or initial load
+        if selected_filters:
+            # Active filters: re-fetch with both query and filters
+            current_page_number = 1
+            data = fetch_search_results(
+                query=query,
+                filters=selected_filters,
+                page=1,
+                size=PAGE_SIZE,
+                search_mode="targets",
+            )
+            results = data.get("results", [])
+            facets = data.get("facets", {})
+            total = data.get("total", 0)
+            total_pages = data.get("total_pages", 0)
+        else:
+            # No filters: use store data directly
+            results = store_data.get("results", [])
+            facets = store_data.get("facets", {})
+            total = store_data.get("total", 0)
+            total_pages = store_data.get("total_pages", 0)
+            current_page_number = store_data.get("current_page", 1)
     elif "targets-page-prev" in triggered_prop:
         current_page_number = max(1, (current_page or 1) - 1)
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
@@ -358,7 +339,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         old_total_pages = store_data.get("total_pages", 1)
         current_page_number = min(old_total_pages, (current_page or 1) + 1)
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
@@ -372,7 +353,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         # Facet changed: reset to page 1 with new filters
         current_page_number = 1
         data = fetch_search_results(
-            query=None,
+            query=query,
             filters=selected_filters or None,
             page=1,
             size=PAGE_SIZE,
@@ -426,107 +407,6 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
 
     pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
     page_info = f"Page {current_page_number} of {total_pages} ({total} results)"
-    prev_disabled = current_page_number <= 1
-    next_disabled = current_page_number >= total_pages
-
-    return (
-        table,
-        pagination_style,
-        page_info,
-        prev_disabled,
-        next_disabled,
-        current_page_number,
-        filters_children,
-        {"display": "flex", "justifyContent": "flex-end"},
-    )
-
-
-def _render_client_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering in client-side filtering mode (with query)."""
-    all_results = store_data.get("results", [])
-    original_facets = store_data.get("facets", {})
-
-    # Apply client-side filtering
-    def matches_filters(result, filters):
-        for field, sel_values in filters.items():
-            if not sel_values:
-                continue
-            result_value = result.get(field)
-            if result_value is None:
-                return False
-            if isinstance(result_value, list):
-                if not any(v in sel_values for v in result_value):
-                    return False
-            else:
-                if result_value not in sel_values:
-                    return False
-        return True
-
-    if selected_filters:
-        filtered_results = [
-            r for r in all_results if matches_filters(r, selected_filters)
-        ]
-    else:
-        filtered_results = all_results
-
-    # Recalculate facet counts
-    if selected_filters:
-        facets = recalculate_facets(filtered_results, original_facets, "targets")
-    else:
-        facets = original_facets
-
-    # Pagination
-    total_results = len(filtered_results)
-    total_pages = max(1, (total_results + PAGE_SIZE - 1) // PAGE_SIZE)
-
-    current_page_number = current_page or 1
-
-    if "targets-results-store" in triggered_prop or "facet-filter" in triggered_prop:
-        current_page_number = 1
-    elif "targets-page-prev" in triggered_prop:
-        current_page_number = max(1, current_page_number - 1)
-    elif "targets-page-next" in triggered_prop:
-        current_page_number = min(total_pages, current_page_number + 1)
-
-    if current_page_number > total_pages:
-        current_page_number = total_pages
-    if current_page_number < 1:
-        current_page_number = 1
-
-    start_idx = (current_page_number - 1) * PAGE_SIZE
-    end_idx = start_idx + PAGE_SIZE
-    page_results = filtered_results[start_idx:end_idx]
-
-    if not page_results and total_results == 0:
-        filters_children = build_filter_controls(
-            facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
-        )
-        return (
-            dbc.Alert(
-                [
-                    html.I(className="bi bi-info-circle me-2"),
-                    "No targets found matching your filters.",
-                ],
-                color="info",
-                className="shadow-sm",
-                style={"borderRadius": "10px"},
-            ),
-            {"display": "none"},
-            f"Page 1 of {total_pages} ({total_results} results)",
-            True,
-            True,
-            current_page_number,
-            filters_children,
-            {"display": "none"},
-        )
-
-    table = render_targets_table(page_results)
-    filters_children = build_filter_controls(
-        facets, selected_filters, FACET_FIELDS, "targets", id_prefix="targets"
-    )
-
-    pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
-    page_info = f"Page {current_page_number} of {total_pages} ({total_results} results)"
     prev_disabled = current_page_number <= 1
     next_disabled = current_page_number >= total_pages
 


### PR DESCRIPTION
- Fix client-side and server-side filtering and search to work correctly together
- Fix facets dropdown menus not updating properly
- Streamline dataset details page: show key fields (Study Title, Authors, Year, Experiment Title, Data Modality, Perturbation Type) by default and collapse remaining metadata under "Other Metadata Fields"
- Make Study Title a clickable link using Study URI
- Rename "Data Modalities" to "Data Modality"
- Remove redundant "Data" scroll button from dataset page header