### PR TITLE
Use search_after cursor pagination to support browsing beyond 10k res…

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Dict, Any
 from elasticsearch import AsyncElasticsearch
 import asyncpg
 from dotenv import load_dotenv
+import json
 import re
 from urllib.parse import urlparse
 from contextlib import asynccontextmanager
@@ -458,6 +459,7 @@ async def perform_search(
     page: int,
     size: int,
     search_mode: str = "targets",
+    search_after: Optional[List[Any]] = None,
 ) -> SearchResponse:
     """Perform the actual search operation"""
     is_dataset_mode = search_mode == "datasets"
@@ -467,24 +469,36 @@ async def perform_search(
         es_query = build_dataset_elasticsearch_query(query, filters)
         facet_fields = DATASET_FACET_FIELDS
         es_index = ES_DATASET_SUMMARY
+        sort_field = "dataset_id"
     else:
         es_query = build_elasticsearch_query(query, filters)
         facet_fields = FACET_FIELDS
         es_index = ES_TARGET_SUMMARY
+        sort_field = "perturbed_target_symbol"
 
     aggs = build_aggregations(facet_fields)
 
-    from_ = (page - 1) * size
+    # Deterministic sort for search_after pagination support.
+    # Always include _score first (1.0 for match_all) and a unique tiebreaker.
+    sort = [{"_score": "desc"}, {sort_field: "asc"}]
+
+    search_kwargs = {
+        "index": es_index,
+        "query": es_query,
+        "aggs": aggs,
+        "size": size,
+        "sort": sort,
+        "track_total_hits": True,
+    }
+
+    if search_after is not None:
+        search_kwargs["search_after"] = search_after
+    else:
+        search_kwargs["from_"] = (page - 1) * size
 
     # Execute search with aggregations
     try:
-        response = await db_pools["es"].search(
-            index=es_index,
-            query=es_query,
-            aggs=aggs,
-            from_=from_,
-            size=size,
-        )
+        response = await db_pools["es"].search(**search_kwargs)
     except Exception as e:
         error_detail = str(e)
         raise HTTPException(
@@ -493,11 +507,15 @@ async def perform_search(
 
     # Process results
     hits = response.get("hits", {})
-    results = [hit["_source"] for hit in hits.get("hits", [])]
+    hit_list = hits.get("hits", [])
+    results = [hit["_source"] for hit in hit_list]
 
     total = hits.get("total", {}).get("value", 0)
     total_pages = (total + size - 1) // size if total > 0 else 0
     aggregations = response.get("aggregations", {})
+
+    # Extract search_after cursor from last hit for deep pagination
+    last_sort = hit_list[-1]["sort"] if hit_list else None
 
     # Build a lookup of lowercase → original-case values from result _source
     # fields, so we can restore proper display case for aggregation keys
@@ -542,6 +560,7 @@ async def perform_search(
         total_pages=total_pages,
         results=results,
         facets=facets,
+        search_after=last_sort,
     )
 
 
@@ -658,6 +677,10 @@ async def search_get(
     ),
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     size: int = Query(6, ge=1, le=100, description="Number of results per page"),
+    search_after: Optional[str] = Query(
+        None,
+        description="JSON-encoded search_after cursor for deep pagination beyond 10k results",
+    ),
 ):
     """
     Search endpoint (GET) with pagination, facets, filtering, and text search.
@@ -680,7 +703,15 @@ async def search_get(
         developmental_stage_labels,
         disease_labels,
     )
-    return await perform_search(query, filters, page, size, search_mode)
+    parsed_search_after = None
+    if search_after:
+        try:
+            parsed_search_after = json.loads(search_after)
+        except (json.JSONDecodeError, TypeError):
+            parsed_search_after = None
+    return await perform_search(
+        query, filters, page, size, search_mode, parsed_search_after
+    )
 
 
 @app.post("/search", response_model=SearchResponse)
@@ -695,6 +726,7 @@ async def search_post(request: SearchRequest):
         request.page,
         request.size,
         getattr(request, "search_mode", "targets"),
+        request.search_after,
     )
 
 

--- a/be/models.py
+++ b/be/models.py
@@ -19,6 +19,9 @@ class SearchRequest(BaseModel):
     )
     page: int = Field(1, ge=1, description="Page number (1-indexed)")
     size: int = Field(6, ge=1, le=100, description="Number of results per page")
+    search_after: Optional[List[Any]] = Field(
+        None, description="search_after cursor for deep pagination beyond 10k results"
+    )
 
 
 class FacetValue(BaseModel):
@@ -44,6 +47,7 @@ class SearchResponse(BaseModel):
     total_pages: int
     results: List[Dict[str, Any]]
     facets: Any
+    search_after: Optional[List[Any]] = None
 
 
 class SummaryTopEntry(BaseModel):

--- a/fe/pages/datasets.py
+++ b/fe/pages/datasets.py
@@ -194,9 +194,11 @@ layout = html.Div(
                         "total": 0,
                         "total_pages": 0,
                         "current_page": 1,
+                        "search_after": None,
                     },
                 ),
                 dcc.Store(id="datasets-page-store", data=1),
+                dcc.Store(id="datasets-cursor-store", data={}),
             ],
             className="content-container",
         ),
@@ -240,6 +242,7 @@ def load_datasets_data(query, _n_clicks):
         "total": data.get("total", 0),
         "total_pages": data.get("total_pages", 0),
         "current_page": 1,
+        "search_after": data.get("search_after"),
     }
 
 
@@ -252,15 +255,23 @@ def load_datasets_data(query, _n_clicks):
     Output("datasets-page-store", "data"),
     Output("datasets-facets", "children"),
     Output("datasets-download-container", "style"),
+    Output("datasets-cursor-store", "data"),
     Input("datasets-results-store", "data"),
     Input({"type": "datasets-facet-filter", "field": ALL}, "value"),
     Input("datasets-page-prev", "n_clicks"),
     Input("datasets-page-next", "n_clicks"),
     State({"type": "datasets-facet-filter", "field": ALL}, "id"),
     State("datasets-page-store", "data"),
+    State("datasets-cursor-store", "data"),
 )
 def render_datasets_results(
-    store_data, selected_values, prev_clicks, next_clicks, filter_ids, current_page
+    store_data,
+    selected_values,
+    prev_clicks,
+    next_clicks,
+    filter_ids,
+    current_page,
+    cursor_store,
 ):
     """Render dataset results with server-side or client-side filtering and pagination."""
     ctx = callback_context
@@ -276,6 +287,7 @@ def render_datasets_results(
             1,
             filter_placeholder("Search to see available filters."),
             {"display": "none"},
+            {},
         )
 
     # Build selected filters dict
@@ -290,19 +302,22 @@ def render_datasets_results(
     triggered_prop = trigger or ""
 
     return _render_server_side(
-        store_data, selected_filters, triggered_prop, current_page
+        store_data, selected_filters, triggered_prop, current_page, cursor_store or {}
     )
 
 
-def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering with server-side pagination and filtering."""
+def _render_server_side(
+    store_data, selected_filters, triggered_prop, current_page, cursor_store
+):
+    """Handle rendering with server-side pagination and cursor-based deep pagination."""
     current_page_number = store_data.get("current_page", 1) or 1
     query = store_data.get("query") or None
+    new_cursor_store = dict(cursor_store)
+    response_search_after = None
 
     if "datasets-results-store" in triggered_prop:
-        # New search or initial load
+        # New search or initial load — reset cursors
         if selected_filters:
-            # Active filters: re-fetch with both query and filters
             current_page_number = 1
             data = fetch_search_results(
                 query=query,
@@ -315,40 +330,59 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
             facets = data.get("facets", {})
             total = data.get("total", 0)
             total_pages = data.get("total_pages", 0)
+            response_search_after = data.get("search_after")
         else:
-            # No filters: use store data directly
             results = store_data.get("results", [])
             facets = store_data.get("facets", {})
             total = store_data.get("total", 0)
             total_pages = store_data.get("total_pages", 0)
             current_page_number = store_data.get("current_page", 1)
+            response_search_after = store_data.get("search_after")
+        # Reset cursor store for the new search context
+        new_cursor_store = {}
+        if response_search_after is not None:
+            new_cursor_store["2"] = response_search_after
     elif "datasets-page-prev" in triggered_prop:
         current_page_number = max(1, (current_page or 1) - 1)
+        cursor = (
+            new_cursor_store.get(str(current_page_number))
+            if current_page_number > 1
+            else None
+        )
         data = fetch_search_results(
             query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
             search_mode="datasets",
+            search_after=cursor,
         )
         results = data.get("results", [])
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        if response_search_after is not None:
+            new_cursor_store[str(current_page_number + 1)] = response_search_after
     elif "datasets-page-next" in triggered_prop:
         old_total_pages = store_data.get("total_pages", 1)
         current_page_number = min(old_total_pages, (current_page or 1) + 1)
+        cursor = new_cursor_store.get(str(current_page_number))
         data = fetch_search_results(
             query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
             search_mode="datasets",
+            search_after=cursor,
         )
         results = data.get("results", [])
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        if response_search_after is not None:
+            new_cursor_store[str(current_page_number + 1)] = response_search_after
     elif "facet-filter" in triggered_prop:
         # Facet changed: reset to page 1 with new filters
         current_page_number = 1
@@ -363,6 +397,10 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        new_cursor_store = {}
+        if response_search_after is not None:
+            new_cursor_store["2"] = response_search_after
     else:
         # Fallback: use store data
         results = store_data.get("results", [])
@@ -398,6 +436,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
             current_page_number,
             filters_children,
             {"display": "none"},
+            new_cursor_store,
         )
 
     table = render_datasets_table(results)
@@ -419,6 +458,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         current_page_number,
         filters_children,
         {"display": "flex", "justifyContent": "flex-end"},
+        new_cursor_store,
     )
 
 

--- a/fe/pages/targets.py
+++ b/fe/pages/targets.py
@@ -194,9 +194,11 @@ layout = html.Div(
                         "total": 0,
                         "total_pages": 0,
                         "current_page": 1,
+                        "search_after": None,
                     },
                 ),
                 dcc.Store(id="targets-page-store", data=1),
+                dcc.Store(id="targets-cursor-store", data={}),
             ],
             className="content-container",
         ),
@@ -240,6 +242,7 @@ def load_targets_data(query, _n_clicks):
         "total": data.get("total", 0),
         "total_pages": data.get("total_pages", 0),
         "current_page": 1,
+        "search_after": data.get("search_after"),
     }
 
 
@@ -252,15 +255,23 @@ def load_targets_data(query, _n_clicks):
     Output("targets-page-store", "data"),
     Output("targets-facets", "children"),
     Output("targets-download-container", "style"),
+    Output("targets-cursor-store", "data"),
     Input("targets-results-store", "data"),
     Input({"type": "targets-facet-filter", "field": ALL}, "value"),
     Input("targets-page-prev", "n_clicks"),
     Input("targets-page-next", "n_clicks"),
     State({"type": "targets-facet-filter", "field": ALL}, "id"),
     State("targets-page-store", "data"),
+    State("targets-cursor-store", "data"),
 )
 def render_targets_results(
-    store_data, selected_values, prev_clicks, next_clicks, filter_ids, current_page
+    store_data,
+    selected_values,
+    prev_clicks,
+    next_clicks,
+    filter_ids,
+    current_page,
+    cursor_store,
 ):
     """Render target results with server-side or client-side filtering and pagination."""
     ctx = callback_context
@@ -276,6 +287,7 @@ def render_targets_results(
             1,
             filter_placeholder("Search to see available filters."),
             {"display": "none"},
+            {},
         )
 
     # Build selected filters dict
@@ -290,19 +302,22 @@ def render_targets_results(
     triggered_prop = trigger or ""
 
     return _render_server_side(
-        store_data, selected_filters, triggered_prop, current_page
+        store_data, selected_filters, triggered_prop, current_page, cursor_store or {}
     )
 
 
-def _render_server_side(store_data, selected_filters, triggered_prop, current_page):
-    """Handle rendering with server-side pagination and filtering."""
+def _render_server_side(
+    store_data, selected_filters, triggered_prop, current_page, cursor_store
+):
+    """Handle rendering with server-side pagination and cursor-based deep pagination."""
     current_page_number = store_data.get("current_page", 1) or 1
     query = store_data.get("query") or None
+    new_cursor_store = dict(cursor_store)
+    response_search_after = None
 
     if "targets-results-store" in triggered_prop:
-        # New search or initial load
+        # New search or initial load — reset cursors
         if selected_filters:
-            # Active filters: re-fetch with both query and filters
             current_page_number = 1
             data = fetch_search_results(
                 query=query,
@@ -315,40 +330,59 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
             facets = data.get("facets", {})
             total = data.get("total", 0)
             total_pages = data.get("total_pages", 0)
+            response_search_after = data.get("search_after")
         else:
-            # No filters: use store data directly
             results = store_data.get("results", [])
             facets = store_data.get("facets", {})
             total = store_data.get("total", 0)
             total_pages = store_data.get("total_pages", 0)
             current_page_number = store_data.get("current_page", 1)
+            response_search_after = store_data.get("search_after")
+        # Reset cursor store for the new search context
+        new_cursor_store = {}
+        if response_search_after is not None:
+            new_cursor_store["2"] = response_search_after
     elif "targets-page-prev" in triggered_prop:
         current_page_number = max(1, (current_page or 1) - 1)
+        cursor = (
+            new_cursor_store.get(str(current_page_number))
+            if current_page_number > 1
+            else None
+        )
         data = fetch_search_results(
             query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
             search_mode="targets",
+            search_after=cursor,
         )
         results = data.get("results", [])
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        if response_search_after is not None:
+            new_cursor_store[str(current_page_number + 1)] = response_search_after
     elif "targets-page-next" in triggered_prop:
         old_total_pages = store_data.get("total_pages", 1)
         current_page_number = min(old_total_pages, (current_page or 1) + 1)
+        cursor = new_cursor_store.get(str(current_page_number))
         data = fetch_search_results(
             query=query,
             filters=selected_filters or None,
             page=current_page_number,
             size=PAGE_SIZE,
             search_mode="targets",
+            search_after=cursor,
         )
         results = data.get("results", [])
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        if response_search_after is not None:
+            new_cursor_store[str(current_page_number + 1)] = response_search_after
     elif "facet-filter" in triggered_prop:
         # Facet changed: reset to page 1 with new filters
         current_page_number = 1
@@ -363,6 +397,10 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         facets = data.get("facets", {})
         total = data.get("total", 0)
         total_pages = data.get("total_pages", 0)
+        response_search_after = data.get("search_after")
+        new_cursor_store = {}
+        if response_search_after is not None:
+            new_cursor_store["2"] = response_search_after
     else:
         # Fallback: use store data
         results = store_data.get("results", [])
@@ -398,6 +436,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
             current_page_number,
             filters_children,
             {"display": "none"},
+            new_cursor_store,
         )
 
     table = render_targets_table(results)
@@ -419,6 +458,7 @@ def _render_server_side(store_data, selected_filters, triggered_prop, current_pa
         current_page_number,
         filters_children,
         {"display": "flex", "justifyContent": "flex-end"},
+        new_cursor_store,
     )
 
 

--- a/fe/utils.py
+++ b/fe/utils.py
@@ -83,6 +83,7 @@ def fetch_search_results(
     page: int = 1,
     size: int = 6,
     search_mode: str = "targets",
+    search_after: Optional[List[Any]] = None,
 ) -> Dict[str, Any]:
     """Fetch search results from backend API"""
     try:
@@ -96,6 +97,9 @@ def fetch_search_results(
                 if values:
                     params[field] = ",".join(values)
 
+        if search_after is not None:
+            params["search_after"] = json.dumps(search_after)
+
         response = requests.get(f"{BACKEND_URL}/search", params=params, timeout=10)
         response.raise_for_status()
         return response.json()
@@ -108,6 +112,7 @@ def fetch_search_results(
             "total_pages": 0,
             "results": [],
             "facets": {},
+            "search_after": None,
         }
 
 
@@ -117,7 +122,9 @@ def fetch_all_search_results(
     page_size: int = 100,
     search_mode: str = "targets",
 ) -> List[Dict[str, Any]]:
-    """Fetch all search results by paginating through the API.
+    """Fetch all search results using cursor-based pagination.
+
+    Uses search_after cursors to paginate beyond the 10k ES limit.
 
     Args:
         query: Search query string
@@ -129,18 +136,24 @@ def fetch_all_search_results(
         List of all result records
     """
     all_results = []
+    cursor = None
     page = 1
 
     while True:
         data = fetch_search_results(
-            query=query, filters=filters, page=page, size=page_size,
+            query=query,
+            filters=filters,
+            page=page,
+            size=page_size,
             search_mode=search_mode,
+            search_after=cursor,
         )
         results = data.get("results", [])
         all_results.extend(results)
 
+        cursor = data.get("search_after")
         total_pages = data.get("total_pages", 1)
-        if page >= total_pages or not results:
+        if not results or cursor is None or page >= total_pages:
             break
         page += 1
 


### PR DESCRIPTION
Elasticsearch limits offset-based pagination (from + size) to 10,000 results. Switch to cursor-based search_after pagination in the backend and propagate cursors through the frontend Targets and Datasets tabs, allowing users to page through the full result set.