### PR TITLE
Fix facet dropdown menu being hidden behind sibling cards

### DIFF
--- a/fe/assets/custom.css
+++ b/fe/assets/custom.css
@@ -384,6 +384,11 @@ body {
     box-shadow: 0 4px 12px rgba(0,0,0,0.12);
 }
 
+/* When a dropdown inside a facet card is open, raise that card above siblings */
+.facet-controls .facet-filter-card:focus-within {
+    z-index: 9999 !important;
+}
+
 .facet-controls .facet-filter-card .card-body {
     overflow: visible;
 }


### PR DESCRIPTION
When bottom facet dropdowns (e.g. Disease) open upward, the menu was obscured by higher-z-index sibling cards. Use :focus-within to temporarily raise the active card above its siblings.