### PR TITLE
Use the actual ingested_at value for Perturb-Seq tables

### DIFF
--- a/dwh/bq_dbt/models/perturb_seq_dea.sql
+++ b/dwh/bq_dbt/models/perturb_seq_dea.sql
@@ -19,5 +19,5 @@ select
     score_name,
     score_value,
     cell_type,
-    current_timestamp() as max_ingested_at
+    ingested_at as max_ingested_at
 from {{ source("perturb_seq", "pertpy_dea") }}

--- a/dwh/bq_dbt/models/perturb_seq_gsea.sql
+++ b/dwh/bq_dbt/models/perturb_seq_gsea.sql
@@ -22,5 +22,5 @@ select
     geneset_size,
     leading_edge,
     cell_type,
-    current_timestamp() as max_ingested_at
+    ingested_at as max_ingested_at
 from {{ source("perturb_seq", "pertpy_gsea") }}


### PR DESCRIPTION
A small but important change to use the *actual* ingested_at value (not the current timestamp) for Perturb-Seq, because now it is present in the source data 