### PR TITLE
Postgres refactor: granular sync by dataset, change of approach, more automation & performance improvements

### DIFF
--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -57,8 +57,7 @@ python3 bq_to_postgres.py \
     --bq-table ${BQ_TABLE} \
     --bq-location ${BQ_LOCATION} \
     --pg-conn "${PG_CONN}" \
-    --pg-table ${PG_TABLE} \
-    --gcs-bucket ${GCLOUD_TMP_BUCKET}
+    --pg-table ${PG_TABLE}
 ```
 
 ## 6. Create indexes and summary views (only when the table is fully ingested)

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -24,7 +24,7 @@ dev_secrets
 gcloud compute instances create bq-to-pg-projector \
     --project=${GCLOUD_PROJECT} \
     --zone=${GCLOUD_ZONE} \
-    --machine-type=e2-standard-4 \
+    --machine-type=e2-highmem-4 \
     --network=default \
     --scopes=https://www.googleapis.com/auth/cloud-platform
 ```

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -58,28 +58,7 @@ python3 bq_to_postgres.py \
     --gcs-bucket "${GCLOUD_TMP_BUCKET}"
 ```
 
-## 6. Summary views
-Summary materialized views (e.g. `perturb_seq_summary_perturbation`, `perturb_seq_summary_effect`, `perturb_seq_summary_dataset`) and their indexes are now created automatically by the script. No manual SQL is needed.
-
-## Monitoring
-You can use this query in a separate psql session to monitor the progress of index creation:
-```sql
-SELECT
-    p.pid,
-    p.datname,
-    c.relname AS table_name,
-    i.relname AS index_name,
-    p.phase,
-    p.blocks_total,
-    p.blocks_done,
-    ROUND(100.0 * p.blocks_done / NULLIF(p.blocks_total, 0), 1) AS pct_done
-FROM pg_stat_progress_create_index p
-JOIN pg_class c ON p.relid = c.oid
-LEFT JOIN pg_class i ON p.index_relid = i.oid;
-\watch 10
-```
-
-## 7. Remove the VM
+## 6. Remove the VM
 Once the ingestion is complete (including any index creation as described above), exit the session and remove the instance:
 ```bash
 gcloud compute instances delete bq-to-pg-projector --project ${GCLOUD_PROJECT} --zone=${GCLOUD_ZONE}

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -55,7 +55,8 @@ python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
     --bq-location ${BQ_LOCATION} \
     --pg-conn "${PG_CONN}" \
-    --gcs-bucket "${GCLOUD_TMP_BUCKET}"
+    --gcs-bucket "${GCLOUD_TMP_BUCKET}" \
+    --drop-and-recreate-indexes
 ```
 
 ## 6. Create summary views

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -55,53 +55,11 @@ python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
     --bq-location ${BQ_LOCATION} \
     --pg-conn "${PG_CONN}" \
-    --gcs-bucket "${GCLOUD_TMP_BUCKET}" \
-    --drop-and-recreate-indexes
+    --gcs-bucket "${GCLOUD_TMP_BUCKET}"
 ```
 
-## 6. Create summary views
-Run `psql $PG_CONN` and create the summary views.
-
-### Perturb-Seq Summary Views
-```sql
-CREATE MATERIALIZED VIEW perturb_seq_summary_perturbation AS
-SELECT
-    dataset_id,
-    perturbed_target_symbol,
-    COUNT(*) AS n_total,
-    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
-    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up
-FROM public.perturb_seq_dea
-WHERE padj <= 0.05
-GROUP BY dataset_id, perturbed_target_symbol;
-
-CREATE MATERIALIZED VIEW perturb_seq_summary_effect AS
-SELECT
-    dataset_id,
-    gene,
-    COUNT(*) AS n_total,
-    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
-    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up,
-    AVG(score_value) AS avg_score
-FROM public.perturb_seq_dea
-WHERE padj <= 0.05
-GROUP BY dataset_id, gene;
-
-CREATE MATERIALIZED VIEW perturb_seq_summary_dataset AS
-SELECT
-    dataset_id,
-    COUNT(*) AS n_total
-FROM public.perturb_seq_dea
-WHERE gene IS NOT NULL
-GROUP BY dataset_id;
-
-CREATE UNIQUE INDEX idx_perturb_seq_summary_perturbation_pk
-  ON perturb_seq_summary_perturbation (dataset_id, perturbed_target_symbol);
-CREATE UNIQUE INDEX idx_perturb_seq_summary_effect_pk
-  ON perturb_seq_summary_effect (dataset_id, gene);
-CREATE UNIQUE INDEX idx_perturb_seq_summary_dataset_pk
-  ON perturb_seq_summary_dataset (dataset_id);
-```
+## 6. Summary views
+Summary materialized views (e.g. `perturb_seq_summary_perturbation`, `perturb_seq_summary_effect`, `perturb_seq_summary_dataset`) and their indexes are now created automatically by the script. No manual SQL is needed.
 
 ## Monitoring
 You can use this query in a separate psql session to monitor the progress of index creation:

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -24,7 +24,7 @@ dev_secrets
 gcloud compute instances create bq-to-pg-projector \
     --project=${GCLOUD_PROJECT} \
     --zone=${GCLOUD_ZONE} \
-    --machine-type=e2-medium \
+    --machine-type=e2-standard-4 \
     --network=default \
     --scopes=https://www.googleapis.com/auth/cloud-platform
 ```

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -54,7 +54,8 @@ Note: you should set `$PG_CONN` to `$PG_CONN_INTERNAL` from the list of secrets,
 python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
     --bq-location ${BQ_LOCATION} \
-    --pg-conn "${PG_CONN}"
+    --pg-conn "${PG_CONN}" \
+    --gcs-bucket "${GCLOUD_TMP_BUCKET}"
 ```
 
 ## 6. Create indexes and summary views (only when the table is fully ingested)

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -49,15 +49,12 @@ pip3 install -r requirements.txt
 
 ## 5. Run the script
 Note: you should set `$PG_CONN` to `$PG_CONN_INTERNAL` from the list of secrets, as the VM is connected to the VPC and should connect to the SQL instance via its private IP.
+
 ```bash
-export BQ_TABLE=...
-export PG_TABLE=...
 python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
-    --bq-table ${BQ_TABLE} \
     --bq-location ${BQ_LOCATION} \
-    --pg-conn "${PG_CONN}" \
-    --pg-table ${PG_TABLE}
+    --pg-conn "${PG_CONN}"
 ```
 
 ## 6. Create indexes and summary views (only when the table is fully ingested)

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -55,8 +55,30 @@ python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
     --bq-location ${BQ_LOCATION} \
     --pg-conn "${PG_CONN}" \
-    --gcs-bucket "${GCLOUD_TMP_BUCKET}"
+    --gcs-bucket "${GCLOUD_TMP_BUCKET}" \
+    --ingestion-mode copy_nonblocking
 ```
+
+### Ingestion Modes
+
+The script supports three modes of operation via `--ingestion-mode`:
+
+1.  `live_nonblocking` (Live):
+    -   Perform all operations (delete old rows, add new rows) in a single transaction.
+    -   Does not create table copies or drop indexes.
+    -   Ideal for small datasets or frequent updates where table availability is paramount.
+    -   Non-blocking (keeps indexes online), but slower ingestion.
+
+2.  `copy_nonblocking` (Copy & Swap):
+    -   The default mode.
+    -   Creates a copy of the table (without indexes), ingests data into it, and then swaps it with the original table.
+    -   Non-blocking (original table remains available during ingestion).
+    -   Slowest due to full table copy, but safe and robust.
+
+3.  `direct_blocking` (Direct):
+    -   Drops indexes, ingests new data directly into the table, then recreates indexes and refreshes materialized views in a single huge transaction.
+    -   Most efficient (no copying), but **blocking** (table is locked/indexes dropped during the process).
+    -   Ideal for overnight synchronization or when the environment is not in use.
 
 ## 6. Remove the VM
 Once the ingestion is complete (including any index creation as described above), exit the session and remove the instance:

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -50,40 +50,73 @@ pip3 install -r requirements.txt
 ## 5. Run the script
 Note: you should set `$PG_CONN` to `$PG_CONN_INTERNAL` from the list of secrets, as the VM is connected to the VPC and should connect to the SQL instance via its private IP.
 
+Standard mode (keeps indexes, updates data):
+```bash
+python3 bq_to_postgres.py \
+    --bq-dataset ${BQ_DATASET} \
+    --bq-location ${BQ_LOCATION} \
+    --pg-conn "${PG_CONN}" \
+    --gcs-bucket "${GCLOUD_TMP_BUCKET}"
+```
+
+Mode with index dropping (drops indexes -> updates data -> recreates indexes):
+Use this for large updates where updating indexes row-by-row is too slow.
 ```bash
 python3 bq_to_postgres.py \
     --bq-dataset ${BQ_DATASET} \
     --bq-location ${BQ_LOCATION} \
     --pg-conn "${PG_CONN}" \
     --gcs-bucket "${GCLOUD_TMP_BUCKET}" \
-    --ingestion-mode copy_nonblocking
+    --drop-and-recreate-indexes
 ```
-
-### Ingestion Modes
-
-The script supports three modes of operation via `--ingestion-mode`:
-
-1.  `live_nonblocking` (Live):
-    -   Perform all operations (delete old rows, add new rows) in a single transaction.
-    -   Does not create table copies or drop indexes.
-    -   Ideal for small datasets or frequent updates where table availability is paramount.
-    -   Non-blocking (keeps indexes online), but slower ingestion.
-
-2.  `copy_nonblocking` (Copy & Swap):
-    -   The default mode.
-    -   Creates a copy of the table (without indexes), ingests data into it, and then swaps it with the original table.
-    -   Non-blocking (original table remains available during ingestion).
-    -   Slowest due to full table copy, but safe and robust.
-
-3.  `direct_blocking` (Direct):
-    -   Drops indexes, ingests new data directly into the table, then recreates indexes and refreshes materialized views in a single huge transaction.
-    -   Most efficient (no copying), but **blocking** (table is locked/indexes dropped during the process).
-    -   Ideal for overnight synchronization or when the environment is not in use.
 
 ## 6. Remove the VM
 Once the ingestion is complete (including any index creation as described above), exit the session and remove the instance:
 ```bash
 gcloud compute instances delete bq-to-pg-projector --project ${GCLOUD_PROJECT} --zone=${GCLOUD_ZONE}
+```
+
+# Materialized Views
+
+The script expects the following materialized views to exist for `perturb_seq_dea`. It will refresh them concurrently after data sync.
+
+```sql
+CREATE MATERIALIZED VIEW perturb_seq_summary_perturbation AS
+SELECT
+    dataset_id,
+    perturbed_target_symbol,
+    COUNT(*) AS n_total,
+    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
+    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up
+FROM perturb_seq_dea
+WHERE padj <= 0.05
+GROUP BY dataset_id, perturbed_target_symbol;
+
+CREATE UNIQUE INDEX idx_perturb_seq_summary_perturbation_pk ON perturb_seq_summary_perturbation (dataset_id, perturbed_target_symbol);
+
+CREATE MATERIALIZED VIEW perturb_seq_summary_effect AS
+SELECT
+    dataset_id,
+    gene,
+    COUNT(*) AS n_total,
+    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
+    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up,
+    AVG(score_value) AS avg_score
+FROM perturb_seq_dea
+WHERE padj <= 0.05
+GROUP BY dataset_id, gene;
+
+CREATE UNIQUE INDEX idx_perturb_seq_summary_effect_pk ON perturb_seq_summary_effect (dataset_id, gene);
+
+CREATE MATERIALIZED VIEW perturb_seq_summary_dataset AS
+SELECT
+    dataset_id,
+    COUNT(*) AS n_total
+FROM perturb_seq_dea
+WHERE gene IS NOT NULL
+GROUP BY dataset_id;
+
+CREATE UNIQUE INDEX idx_perturb_seq_summary_dataset_pk ON perturb_seq_summary_dataset (dataset_id);
 ```
 
 # Migrate tables and indexes from development to production

--- a/dwh/postgres/README.md
+++ b/dwh/postgres/README.md
@@ -58,23 +58,11 @@ python3 bq_to_postgres.py \
     --gcs-bucket "${GCLOUD_TMP_BUCKET}"
 ```
 
-## 6. Create indexes and summary views (only when the table is fully ingested)
-Run `psql $PG_CONN` and create the indexes.
+## 6. Create summary views
+Run `psql $PG_CONN` and create the summary views.
 
-## Perturb-Seq
-
-### DEA
+### Perturb-Seq Summary Views
 ```sql
-CREATE INDEX CONCURRENTLY idx_perturbation_dea
-  ON public.perturb_seq_dea (perturbed_target_symbol, dataset_id, padj, score_value, log2foldchange);
-CREATE INDEX CONCURRENTLY idx_phenotype_dea
-  ON public.perturb_seq_dea (gene, dataset_id, padj, score_value, log2foldchange);
-CREATE INDEX CONCURRENTLY idx_perturbation_phenotype_dea
-  ON public.perturb_seq_dea (perturbed_target_symbol, gene, dataset_id, padj, score_value, log2foldchange);
-CREATE INDEX CONCURRENTLY idx_perturb_seq_dea_dataset_id_padj
-  ON public.perturb_seq_dea (dataset_id, padj)
-  WHERE gene IS NOT NULL;
-
 CREATE MATERIALIZED VIEW perturb_seq_summary_perturbation AS
 SELECT
     dataset_id,
@@ -112,29 +100,6 @@ CREATE UNIQUE INDEX idx_perturb_seq_summary_effect_pk
   ON perturb_seq_summary_effect (dataset_id, gene);
 CREATE UNIQUE INDEX idx_perturb_seq_summary_dataset_pk
   ON perturb_seq_summary_dataset (dataset_id);
-```
-
-### GSEA
-```sql
-CREATE INDEX CONCURRENTLY idx_perturbation_gsea
-  ON public.perturb_seq_gsea (perturbed_target_symbol, dataset_id, fdr, nes);
-```
-
-## CRISPR
-```sql
-CREATE INDEX CONCURRENTLY idx_crispr_data_dataset
-  ON public.crispr_data (dataset_id);
-CREATE INDEX CONCURRENTLY idx_crispr_data_target
-  ON public.crispr_data (perturbed_target_symbol);
-
-## MAVE
-```sql
-CREATE INDEX CONCURRENTLY idx_mave_data_dataset
-  ON public.mave_data (dataset_id);
-CREATE INDEX CONCURRENTLY idx_mave_data_target
-  ON public.mave_data (perturbed_target_symbol, dataset_id);
-```
-
 ```
 
 ## Monitoring

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -1,21 +1,34 @@
 import argparse
 import concurrent.futures
-import logging
+import contextlib
+import enum
 import io
+import logging
 import os
 import sys
 import uuid
+import time
 from concurrent.futures import ThreadPoolExecutor
-from google.cloud import bigquery, storage
+from typing import List, Dict, Tuple, Optional, Any
+
 import psycopg2
 from psycopg2 import sql
+from google.cloud import bigquery, storage
 from tqdm import tqdm
 import pyarrow as pa
 import pyarrow.csv as pa_csv
 import pyarrow.parquet as pq
 
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+# ------------------------------------------------------------------------------
+# Configuration & Constants
+# ------------------------------------------------------------------------------
 
 TABLES_TO_SYNC = [
     "crispr_data",
@@ -24,6 +37,8 @@ TABLES_TO_SYNC = [
     "perturb_seq_gsea",
 ]
 
+# Defines indexes for each table.
+# Format: { table_name: [ (index_name, create_sql_template), ... ] }
 INDEX_DEFINITIONS = {
     "perturb_seq_dea": [
         (
@@ -71,9 +86,8 @@ INDEX_DEFINITIONS = {
     ],
 }
 
-# Materialized view definitions, keyed by base table name.
-# Each entry is (view_name, create_sql_template, [(index_name, index_sql_template), ...]).
-# Templates use {view} for the view name and {source_table} for the base table.
+# Materialized view definitions.
+# Format: { base_table_name: [ (view_name, create_sql_template, [(index_name, index_sql_template), ...]), ... ] }
 MATERIALIZED_VIEW_DEFINITIONS = {
     "perturb_seq_dea": [
         (
@@ -134,6 +148,23 @@ GROUP BY dataset_id""",
     ],
 }
 
+# Number of threads for concurrent GCS blob download + Parquet-to-CSV conversion.
+GCS_DOWNLOAD_WORKERS = os.cpu_count() or 4
+
+
+class IngestionMode(enum.Enum):
+    LIVE_NONBLOCKING = "live_nonblocking"
+    COPY_NONBLOCKING = "copy_nonblocking"
+    DIRECT_BLOCKING = "direct_blocking"
+
+    def __str__(self):
+        return self.value
+
+
+# ------------------------------------------------------------------------------
+# Helper Functions
+# ------------------------------------------------------------------------------
+
 
 def get_pg_type(field):
     """Maps BigQuery types to PostgreSQL types."""
@@ -153,7 +184,7 @@ def get_pg_type(field):
     return pg_type
 
 
-def get_all_sync_states(cursor):
+def get_all_sync_states(cursor) -> Dict[str, Dict[str, Any]]:
     """Gets the current sync state for all tables and datasets from Postgres."""
     cursor.execute(
         """
@@ -174,7 +205,9 @@ def get_all_sync_states(cursor):
     return states
 
 
-def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_location):
+def get_bq_latest_timestamps_and_counts(
+    bq_client, bq_dataset, bq_table, bq_location
+) -> Dict[str, Tuple[Any, int]]:
     """Gets the latest max_ingested_at and row count for every dataset_id in a BQ table."""
     query = f"""
         SELECT dataset_id, MAX(max_ingested_at) as latest_ts, COUNT(*) as row_count
@@ -186,15 +219,10 @@ def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_loca
     return {row.dataset_id: (row.latest_ts, row.row_count) for row in results}
 
 
-# Number of threads for concurrent GCS blob download + Parquet-to-CSV conversion.
-# Auto-detected from available CPUs; each worker holds one shard in memory.
-GCS_DOWNLOAD_WORKERS = os.cpu_count() or 4
-
-
 def export_dataset_to_gcs(
     bq_client, bq_dataset, bq_table, bq_location, gcs_bucket, gcs_prefix, dataset_id
-):
-    """Exports a specific dataset from BigQuery to GCS as Parquet."""
+) -> str:
+    """Exports a specific dataset from BigQuery to GCS as Parquet via a temp table."""
     destination_uri = f"gs://{gcs_bucket}/{gcs_prefix}-*.parquet"
     dataset_ref = bq_client.dataset(bq_dataset)
 
@@ -237,10 +265,7 @@ def export_dataset_to_gcs(
 
 
 def _convert_array_column(col):
-    """Convert a PyArrow list-typed column to Postgres array literal strings.
-
-    E.g. ["a", "b"] -> '{"a","b"}'
-    """
+    """Convert a PyArrow list-typed column to Postgres array literal strings."""
     result = []
     for val in col.to_pylist():
         if val is None:
@@ -255,10 +280,7 @@ def _convert_array_column(col):
 
 
 def _prepare_table_for_copy(table, bq_schema):
-    """Prepare a PyArrow table for Postgres COPY: handle array columns and
-    convert to a CSV (tab-delimited) bytes buffer using PyArrow's C++ writer.
-    """
-    # Build a set of array column names for targeted conversion
+    """Prepare a PyArrow table for Postgres COPY."""
     array_cols = {f.name for f in bq_schema if f.mode == "REPEATED"}
 
     if array_cols:
@@ -273,7 +295,6 @@ def _prepare_table_for_copy(table, bq_schema):
             {name: col for name, col in zip(table.column_names, new_columns)}
         )
 
-    # Write to TSV bytes buffer using PyArrow's C++ CSV writer (very fast)
     buf = io.BytesIO()
     write_options = pa_csv.WriteOptions(
         include_header=False,
@@ -285,30 +306,20 @@ def _prepare_table_for_copy(table, bq_schema):
 
 
 def _download_and_convert_blob(blob, bq_schema):
-    """Download a single Parquet shard from GCS and convert to a TSV buffer.
-
-    This runs in a worker thread to overlap GCS I/O with CPU work.
-    Returns a BytesIO buffer ready for COPY FROM STDIN.
-    """
+    """Download a single Parquet shard and convert to a TSV buffer."""
     data = blob.download_as_bytes()
     table = pq.read_table(io.BytesIO(data))
     return _prepare_table_for_copy(table, bq_schema)
 
 
 def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
-    """Loads Parquet files from GCS into Postgres using COPY.
-
-    Uses concurrent GCS downloads and PyArrow's native C++ CSV writer for
-    maximum throughput. Blobs are downloaded and converted to TSV in parallel
-    threads; the main thread feeds buffers to Postgres sequentially.
-
-    Memory is bounded: at most ``GCS_DOWNLOAD_WORKERS`` shard buffers exist in
-    memory at any time. New work is only submitted as previous results are
-    consumed by Postgres COPY.
-    """
+    """Loads Parquet files from GCS into Postgres using COPY."""
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
+
+    if not blobs:
+        return
 
     copy_sql = sql.SQL(
         "COPY {} FROM STDIN WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\"', NULL '')"
@@ -319,7 +330,6 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
     pbar = tqdm(total=len(blobs), desc="        Loading shards", leave=False)
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        # Seed the pool with an initial batch (bounded to max_workers)
         pending = {}
         for blob in iter(lambda: next(blob_iter, None), None):
             fut = pool.submit(_download_and_convert_blob, blob, bq_schema)
@@ -327,7 +337,6 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
             if len(pending) >= max_workers:
                 break
 
-        # Sliding window: consume one result, submit one new blob
         while pending:
             done, _ = concurrent.futures.wait(
                 pending, return_when=concurrent.futures.FIRST_COMPLETED
@@ -339,7 +348,6 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
                 del pending[fut]
                 pbar.update(1)
 
-                # Submit next blob if available
                 next_blob = next(blob_iter, None)
                 if next_blob is not None:
                     new_fut = pool.submit(
@@ -400,22 +408,14 @@ def ensure_pg_table_exists(cursor, pg_table, bq_schema):
         )
 
 
-def copy_table(cursor, src_table, dst_table):
-    """Creates a copy of a table with all its data.
-
-    The new table has the same column definitions but no indexes or constraints.
-    """
-    logging.info(f"      - Copying {src_table} -> {dst_table}...")
+def copy_table_schema(cursor, src_table, dst_table):
+    """Creates a dst_table with the same schema as src_table (no data, no indexes)."""
+    logging.info(f"      - Creating {dst_table} (copy of {src_table} schema)...")
     cursor.execute(
         sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(sql.Identifier(dst_table))
     )
     cursor.execute(
         sql.SQL("CREATE TABLE {} (LIKE {})").format(
-            sql.Identifier(dst_table), sql.Identifier(src_table)
-        )
-    )
-    cursor.execute(
-        sql.SQL("INSERT INTO {} SELECT * FROM {}").format(
             sql.Identifier(dst_table), sql.Identifier(src_table)
         )
     )
@@ -428,16 +428,11 @@ def drop_indexes(cursor, table_name, suffix=""):
     logging.info(f"      - Dropping indexes for {table_name}{suffix}...")
     for index_name, _ in INDEX_DEFINITIONS[table_name]:
         idx = f"{index_name}{suffix}"
-        logging.info(f"        Dropping {idx}...")
         cursor.execute(sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(idx)))
 
 
 def create_indexes(cursor, table_name, suffix=""):
-    """Creates all indexes for a given table based on INDEX_DEFINITIONS.
-
-    When suffix is provided, creates indexes with the suffix in both the index
-    name and the target table name.
-    """
+    """Creates all indexes for a given table based on INDEX_DEFINITIONS."""
     if table_name not in INDEX_DEFINITIONS:
         return
     logging.info(
@@ -454,10 +449,7 @@ def create_indexes(cursor, table_name, suffix=""):
 
 
 def create_materialized_views(cursor, table_name, suffix=""):
-    """Creates materialized views (with optional suffix) from definitions.
-
-    Views are created against {table_name}{suffix} and named {view_name}{suffix}.
-    """
+    """Creates materialized views (with optional suffix) from definitions."""
     if table_name not in MATERIALIZED_VIEW_DEFINITIONS:
         return
     for view_name, create_sql_template, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
@@ -466,7 +458,6 @@ def create_materialized_views(cursor, table_name, suffix=""):
         view = f"{view_name}{suffix}"
         source = f"{table_name}{suffix}"
         logging.info(f"      - Creating materialized view {view}...")
-        # Drop if exists (e.g. from a previous failed run)
         cursor.execute(
             sql.SQL("DROP MATERIALIZED VIEW IF EXISTS {}").format(sql.Identifier(view))
         )
@@ -475,7 +466,6 @@ def create_materialized_views(cursor, table_name, suffix=""):
             source_table=sql.Identifier(source).as_string(cursor.connection),
         )
         cursor.execute(create_sql)
-        # Create indexes on the materialized view
         for mv_index_name, mv_index_sql_template in view_indexes:
             idx = f"{mv_index_name}{suffix}"
             logging.info(f"        Creating index {idx}...")
@@ -486,35 +476,54 @@ def create_materialized_views(cursor, table_name, suffix=""):
             cursor.execute(mv_index_sql)
 
 
-def swap_table(conn, table_name):
-    """Atomically swaps {table_name}_upd into {table_name} in a single short transaction.
+def refresh_materialized_views(cursor, table_name, concurrently=False):
+    """Refreshes materialized views associated with the table."""
+    if table_name not in MATERIALIZED_VIEW_DEFINITIONS:
+        return
+    for view_name, _, _ in MATERIALIZED_VIEW_DEFINITIONS[table_name]:
+        logging.info(f"      - Refreshing materialized view {view_name}...")
+        conc_clause = "CONCURRENTLY " if concurrently else ""
+        try:
+            cursor.execute(
+                sql.SQL("REFRESH MATERIALIZED VIEW {}{}").format(
+                    sql.SQL(conc_clause), sql.Identifier(view_name)
+                )
+            )
+        except psycopg2.Error as e:
+            logging.warning(
+                f"        Failed to refresh {view_name} {conc_clause.strip()}: {e}. Trying without CONCURRENTLY."
+            )
+            if concurrently:
+                cursor.connection.rollback()  # Required to recover from error in transaction if any (though we are usually autocommit here if using concurrent)
+                # If we were in a transaction block, we can't retry easily without rollback.
+                # Assuming this runs in a state where we can retry.
+                cursor.execute(
+                    sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
+                        sql.Identifier(view_name)
+                    )
+                )
 
-    Steps (all inside one transaction):
-    1. DROP the original table CASCADE (also drops its materialized views)
-    2. RENAME the _upd table to the original name
-    3. RENAME each _upd materialized view to the original name
-    4. RENAME each _upd index to the original name
-    """
+
+def swap_table(conn, table_name):
+    """Atomically swaps {table_name}_upd into {table_name}."""
     upd = f"{table_name}_upd"
-    logging.info(f"      - Swapping {upd} -> {table_name} (short transaction)...")
+    logging.info(f"      - Swapping {upd} -> {table_name} (atomic transaction)...")
 
     with conn:
         with conn.cursor() as cursor:
-            # 1. Drop original table (CASCADE drops dependent materialized views)
+            # 1. Drop original table (CASCADE drops dependent MVs)
             cursor.execute(
                 sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
                     sql.Identifier(table_name)
                 )
             )
-
-            # 2. Rename _upd table to original
+            # 2. Rename _upd table
             cursor.execute(
                 sql.SQL("ALTER TABLE {} RENAME TO {}").format(
                     sql.Identifier(upd), sql.Identifier(table_name)
                 )
             )
-
-            # 3. Rename indexes on the table
+            # 3. Rename indexes
             if table_name in INDEX_DEFINITIONS:
                 for index_name, _ in INDEX_DEFINITIONS[table_name]:
                     cursor.execute(
@@ -523,8 +532,7 @@ def swap_table(conn, table_name):
                             sql.Identifier(index_name),
                         )
                     )
-
-            # 4. Rename materialized views and their indexes
+            # 4. Rename MVs and their indexes
             if table_name in MATERIALIZED_VIEW_DEFINITIONS:
                 for view_name, _, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
                     table_name
@@ -542,8 +550,271 @@ def swap_table(conn, table_name):
                                 sql.Identifier(mv_index_name),
                             )
                         )
-
     logging.info(f"      - Swap complete for {table_name}.")
+
+
+# ------------------------------------------------------------------------------
+# Core Logic Class
+# ------------------------------------------------------------------------------
+
+
+class TableSynchronizer:
+    def __init__(
+        self,
+        mode: IngestionMode,
+        pg_conn_str: str,
+        bq_dataset: str,
+        bq_location: str,
+        gcs_bucket: str,
+    ):
+        self.mode = mode
+        self.pg_conn_str = pg_conn_str
+        self.bq_dataset = bq_dataset
+        self.bq_location = bq_location
+        self.gcs_bucket = gcs_bucket
+        self.bq_client = bigquery.Client()
+
+    def sync_table(self, table_name: str, plan: Dict[str, Any]):
+        logging.info(f"Syncing table {table_name} in mode {self.mode}...")
+        try:
+            if self.mode == IngestionMode.LIVE_NONBLOCKING:
+                self._sync_live_nonblocking(table_name, plan)
+            elif self.mode == IngestionMode.COPY_NONBLOCKING:
+                self._sync_copy_nonblocking(table_name, plan)
+            elif self.mode == IngestionMode.DIRECT_BLOCKING:
+                self._sync_direct_blocking(table_name, plan)
+
+            logging.info(f"Successfully synced {table_name}.")
+
+        except Exception as e:
+            if isinstance(e, KeyboardInterrupt):
+                raise e
+            logging.error(f"Error syncing {table_name}: {e}.")
+            raise e
+
+    def _get_bq_schema(self, table_name):
+        return self.bq_client.get_table(f"{self.bq_dataset}.{table_name}").schema
+
+    def _ingest_dataset_logic(self, cursor, pg_table, table_name, ds_id, bq_schema):
+        """Standard ingestion: export, delete, copy."""
+        gcs_prefix = f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
+        logging.info(f"    Processing {ds_id}...")
+        try:
+            export_dataset_to_gcs(
+                self.bq_client,
+                self.bq_dataset,
+                table_name,
+                self.bq_location,
+                self.gcs_bucket,
+                gcs_prefix,
+                ds_id,
+            )
+            delete_dataset_from_pg(cursor, pg_table, ds_id)
+            load_parquet_from_gcs_to_pg(
+                cursor,
+                pg_table,
+                self.gcs_bucket,
+                gcs_prefix,
+                bq_schema,
+            )
+        finally:
+            cleanup_gcs(self.gcs_bucket, gcs_prefix)
+
+    def _sync_live_nonblocking(self, table_name: str, plan: Dict[str, Any]):
+        """
+        Mode 1: LIVE_NONBLOCKING
+        - Single transaction for all data updates (Delete + Insert).
+        - No table copying.
+        - No index dropping (updates are slower but non-blocking).
+        - Updates sync_state in same transaction.
+        - Refreshes MVs afterwards (concurrently if possible).
+        """
+        bq_schema = self._get_bq_schema(table_name)
+        datasets = sorted(plan["to_update"] + plan["to_insert"])
+
+        # 1. Data Update Transaction
+        with psycopg2.connect(self.pg_conn_str) as conn:
+            with conn.cursor() as cursor:
+                ensure_pg_table_exists(cursor, table_name, bq_schema)
+
+                # Perform all updates in one transaction
+                logging.info(
+                    f"    Starting data update transaction for {len(datasets)} datasets..."
+                )
+                for ds_id in tqdm(
+                    datasets, desc=f"    Syncing {table_name}", unit="dataset"
+                ):
+                    # Ingest data
+                    self._ingest_dataset_logic(
+                        cursor, table_name, table_name, ds_id, bq_schema
+                    )
+
+                    # Update sync state
+                    bq_ts = plan["bq_info"][ds_id][0]
+                    update_sync_state(cursor, table_name, ds_id, bq_ts)
+
+        # 2. Materialized View Refresh (outside transaction)
+        # We try CONCURRENTLY to be non-blocking.
+        with psycopg2.connect(self.pg_conn_str) as conn:
+            conn.autocommit = (
+                True  # Required for REFRESH MATERIALIZED VIEW CONCURRENTLY
+            )
+            with conn.cursor() as cursor:
+                refresh_materialized_views(cursor, table_name, concurrently=True)
+
+    def _sync_copy_nonblocking(self, table_name: str, plan: Dict[str, Any]):
+        """
+        Mode 2: COPY_NONBLOCKING (Shadow Table Strategy)
+        - Create _upd table (copy).
+        - Drop indexes on _upd.
+        - Ingest data into _upd.
+        - Recreate indexes/MVs on _upd.
+        - Update sync_state updates are collected and applied during swap.
+        - Atomic SWAP.
+        """
+        upd_table = f"{table_name}_upd"
+        bq_schema = self._get_bq_schema(table_name)
+        datasets = sorted(plan["to_update"] + plan["to_insert"])
+
+        sync_state_updates = []  # List of (ds_id, timestamp) to apply at the end
+
+        # Connection for preparation (autocommit to avoid long open tx)
+        conn = psycopg2.connect(self.pg_conn_str)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cursor:
+                ensure_pg_table_exists(cursor, table_name, bq_schema)
+
+                # A. Prepare Shadow Table
+                copy_table_schema(cursor, table_name, upd_table)
+                # Copy data *except* the datasets we are about to update?
+                # The prompt says "delete old rows and add new rows".
+                # Efficient approach: Copy ALL data, then delete specific datasets?
+                # Or Copy filtering out datasets? Filtering in SQL is better.
+                # However, original logic was: Copy everything, then DELETE rows for datasets being updated.
+                # Let's stick to that for simplicity and correctness.
+                logging.info(
+                    f"      - Copying data from {table_name} to {upd_table}..."
+                )
+                cursor.execute(
+                    sql.SQL("INSERT INTO {} SELECT * FROM {}").format(
+                        sql.Identifier(upd_table), sql.Identifier(table_name)
+                    )
+                )
+
+                # B. Drop indexes on _upd (should be empty, but just in case)
+                drop_indexes(cursor, table_name, suffix="_upd")
+
+                # C. Ingest Loop (Non-transactional on shadow table)
+                for ds_id in tqdm(
+                    datasets, desc=f"    Syncing {upd_table}", unit="dataset"
+                ):
+                    self._ingest_dataset_logic(
+                        cursor, upd_table, table_name, ds_id, bq_schema
+                    )
+                    # Collect sync state update
+                    bq_ts = plan["bq_info"][ds_id][0]
+                    sync_state_updates.append((ds_id, bq_ts))
+
+                # D. Recreate Indexes on _upd
+                create_indexes(cursor, table_name, suffix="_upd")
+
+                # E. Create MVs on _upd
+                create_materialized_views(cursor, table_name, suffix="_upd")
+
+        except Exception:
+            # Cleanup on failure
+            with psycopg2.connect(self.pg_conn_str) as clean_conn:
+                clean_conn.autocommit = True
+                with clean_conn.cursor() as clean_cur:
+                    clean_cur.execute(
+                        sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
+                            sql.Identifier(upd_table)
+                        )
+                    )
+            raise
+        finally:
+            conn.close()
+
+        # F. Atomic Swap & Sync State Update
+        with psycopg2.connect(self.pg_conn_str) as swap_conn:
+            try:
+                with swap_conn.cursor() as cursor:
+                    # We need to update sync_state inside this transaction
+                    logging.info("      - Updating sync_state entries...")
+                    for ds_id, bq_ts in sync_state_updates:
+                        update_sync_state(cursor, table_name, ds_id, bq_ts)
+
+                # Perform the swap (logic handles internal transaction management,
+                # but swap_table expects to manage its own transaction block context usually
+                # or be part of one. The `swap_table` function does `with conn:`, which starts a transaction.
+                # So we should pass the connection.
+                swap_table(swap_conn, table_name)
+            except Exception:
+                # If swap fails, clean up
+                with psycopg2.connect(self.pg_conn_str) as clean_conn:
+                    clean_conn.autocommit = True
+                    with clean_conn.cursor() as clean_cur:
+                        clean_cur.execute(
+                            sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
+                                sql.Identifier(upd_table)
+                            )
+                        )
+                raise
+
+    def _sync_direct_blocking(self, table_name: str, plan: Dict[str, Any]):
+        """
+        Mode 3: DIRECT_BLOCKING
+        - Huge single transaction.
+        - Drop indexes.
+        - Delete old -> Ingest new.
+        - Recreate indexes.
+        - Refresh MVs.
+        - Update sync_state.
+        """
+        bq_schema = self._get_bq_schema(table_name)
+        datasets = sorted(plan["to_update"] + plan["to_insert"])
+
+        with psycopg2.connect(self.pg_conn_str) as conn:
+            with conn.cursor() as cursor:
+                ensure_pg_table_exists(cursor, table_name, bq_schema)
+
+                logging.info(f"    Starting blocking transaction for {table_name}...")
+
+                # 1. Drop Indexes
+                drop_indexes(cursor, table_name)
+
+                # 2. Ingest Data
+                for ds_id in tqdm(
+                    datasets, desc=f"    Syncing {table_name}", unit="dataset"
+                ):
+                    self._ingest_dataset_logic(
+                        cursor, table_name, table_name, ds_id, bq_schema
+                    )
+
+                    # Update sync state
+                    bq_ts = plan["bq_info"][ds_id][0]
+                    update_sync_state(cursor, table_name, ds_id, bq_ts)
+
+                # 3. Recreate Indexes
+                create_indexes(cursor, table_name)
+
+                # 4. Refresh Materialized Views (Standard sync refresh inside transaction)
+                if table_name in MATERIALIZED_VIEW_DEFINITIONS:
+                    for view_name, _, _ in MATERIALIZED_VIEW_DEFINITIONS[table_name]:
+                        logging.info(
+                            f"      - Refreshing materialized view {view_name} (blocking)..."
+                        )
+                        cursor.execute(
+                            sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
+                                sql.Identifier(view_name)
+                            )
+                        )
+
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
 
 
 def main():
@@ -553,21 +824,36 @@ def main():
     parser.add_argument("--pg-conn", required=True)
     parser.add_argument("--gcs-bucket", required=True)
     parser.add_argument(
+        "--ingestion-mode",
+        type=IngestionMode,
+        choices=list(IngestionMode),
+        default=IngestionMode.COPY_NONBLOCKING,
+        help="Choose operation mode: live_nonblocking (slow, no copy, no index drop), copy_nonblocking (default, copy table, atomic swap), direct_blocking (fastest, blocks table, drops indexes).",
+    )
+    parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
     )
     args = parser.parse_args()
 
+    mode = args.ingestion_mode
+    # Since argparse with type=Enum returns the Enum member, we can use it directly.
+    # However, depending on python version it might be different. Let's ensure compatibility.
+    # If type=IngestionMode is used, args.ingestion_mode will be an IngestionMode member.
+
+    logging.info(f"Starting sync in mode: {mode}")
+
     bq_client = bigquery.Client()
+    synchronizer = TableSynchronizer(
+        mode, args.pg_conn, args.bq_dataset, args.bq_location, args.gcs_bucket
+    )
 
     try:
-        # Phase 1: Planning (Read-only / Meta-data fetch)
+        # Phase 1: Planning
         with psycopg2.connect(args.pg_conn) as plan_conn:
             with plan_conn.cursor() as cursor:
-                # 1. Fetch current sync states for all tables
                 logging.info("Fetching current sync states from Postgres...")
                 all_states = get_all_sync_states(cursor)
 
-                # 2. Plan sync for each table
                 sync_plan = {}
                 total_datasets = 0
 
@@ -584,6 +870,7 @@ def main():
                     for ds_id, (bq_ts, row_count) in bq_info.items():
                         if ds_id in current_table_states:
                             pg_ts = current_table_states[ds_id]
+                            # Simple timezone-aware comparison
                             if pg_ts is None or bq_ts > pg_ts.replace(
                                 tzinfo=bq_ts.tzinfo
                             ):
@@ -599,7 +886,7 @@ def main():
                         }
                         total_datasets += len(to_update) + len(to_insert)
 
-        # 3. Summary and confirmation
+        # Summary and Confirmation
         if not sync_plan:
             logging.info("Everything is up to date. Nothing to sync.")
             return
@@ -619,6 +906,7 @@ def main():
                 )
 
         print(f"\nTotal datasets to process: {total_datasets}")
+        print(f"Ingestion Mode: {mode}")
         print("--------------------\n")
 
         if not args.yes:
@@ -630,117 +918,11 @@ def main():
                 logging.info("Sync cancelled by user.")
                 sys.exit(0)
 
-        # 4. Execution (Per-table: non-transactional work on _upd copy, then atomic swap)
-        overall_pbar = tqdm(
-            total=total_datasets, desc="Overall Progress", unit="dataset"
-        )
-
+        # Phase 2: Execution
         for table_name, plan in sync_plan.items():
-            logging.info(f"Syncing table {table_name}...")
-            upd_table = f"{table_name}_upd"
+            synchronizer.sync_table(table_name, plan)
 
-            try:
-                # Phase A: Non-transactional work on the _upd copy.
-                # We use autocommit so each statement commits immediately.
-                # This avoids holding a long transaction lock on the original table.
-                conn = psycopg2.connect(args.pg_conn)
-                conn.autocommit = True
-                try:
-                    with conn.cursor() as cursor:
-                        bq_table_obj = bq_client.get_table(
-                            f"{args.bq_dataset}.{table_name}"
-                        )
-                        ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
-
-                        # A1. Copy original table -> _upd table
-                        copy_table(cursor, table_name, upd_table)
-
-                        # A2. Drop indexes on _upd table (they were not copied, but
-                        #     drop just in case from a previous partial run)
-                        drop_indexes(cursor, table_name, suffix="_upd")
-
-                        # A3. For each dataset: delete old rows, load new data
-                        all_to_process = sorted(plan["to_update"] + plan["to_insert"])
-
-                        for ds_id in all_to_process:
-                            bq_timestamp = plan["bq_info"][ds_id][0]
-
-                            # Delete old data if this is an update
-                            if ds_id in plan["to_update"]:
-                                delete_dataset_from_pg(cursor, upd_table, ds_id)
-
-                            # Export from BQ and load into _upd table
-                            gcs_prefix = f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
-                            logging.info(f"    Processing {ds_id}:")
-
-                            try:
-                                logging.info(
-                                    f"      - Exporting from BigQuery to GCS..."
-                                )
-                                export_dataset_to_gcs(
-                                    bq_client,
-                                    args.bq_dataset,
-                                    table_name,
-                                    args.bq_location,
-                                    args.gcs_bucket,
-                                    gcs_prefix,
-                                    ds_id,
-                                )
-
-                                logging.info(f"      - Loading from GCS to Postgres...")
-                                load_parquet_from_gcs_to_pg(
-                                    cursor,
-                                    upd_table,
-                                    args.gcs_bucket,
-                                    gcs_prefix,
-                                    bq_table_obj.schema,
-                                )
-                            finally:
-                                cleanup_gcs(args.gcs_bucket, gcs_prefix)
-
-                            # Update sync state (uses the original table name as key)
-                            update_sync_state(cursor, table_name, ds_id, bq_timestamp)
-
-                            overall_pbar.update(1)
-
-                        # A4. Recreate indexes on _upd table
-                        create_indexes(cursor, table_name, suffix="_upd")
-
-                        # A5. Create materialized views from _upd table
-                        create_materialized_views(cursor, table_name, suffix="_upd")
-
-                finally:
-                    conn.close()
-
-                # Phase B: Atomic swap (short transaction).
-                conn = psycopg2.connect(args.pg_conn)
-                try:
-                    swap_table(conn, table_name)
-                finally:
-                    conn.close()
-
-                logging.info(f"Successfully synced {table_name}.")
-
-            except Exception as e:
-                if isinstance(e, KeyboardInterrupt):
-                    raise e  # Allow Ctrl+C to stop everything
-                logging.error(f"Error syncing {table_name}: {e}. Skipping this table.")
-                # Clean up _upd table if it exists
-                try:
-                    cleanup_conn = psycopg2.connect(args.pg_conn)
-                    cleanup_conn.autocommit = True
-                    with cleanup_conn.cursor() as cleanup_cursor:
-                        cleanup_cursor.execute(
-                            sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
-                                sql.Identifier(upd_table)
-                            )
-                        )
-                    cleanup_conn.close()
-                except Exception:
-                    pass
-
-        overall_pbar.close()
-        logging.info("Multi-table sync operations completed.")
+        logging.info("All sync operations completed.")
 
     except psycopg2.Error as e:
         logging.error(f"Postgres connection error: {e}")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -1,16 +1,66 @@
 import argparse
 import logging
-import uuid
 import io
 import sys
 
-from google.cloud import bigquery, storage
+from google.cloud import bigquery
 import psycopg2
 from psycopg2 import sql
 from tqdm import tqdm
-import pyarrow.parquet as pq
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+class BQRowIteratorIO(io.RawIOBase):
+    """File-like object that streams rows from a BigQuery iterator in TSV format."""
+
+    def __init__(self, row_iterator, bq_schema, pbar=None):
+        self.row_iterator = row_iterator
+        self.bq_schema = bq_schema
+        self.buffer = b""
+        self.pbar = pbar
+
+    def readable(self):
+        return True
+
+    def read(self, n=-1):
+        while not self.buffer:
+            try:
+                row = next(self.row_iterator)
+                if self.pbar:
+                    self.pbar.update(1)
+                line = self._format_row(row) + "\n"
+                self.buffer = line.encode("utf-8")
+            except StopIteration:
+                return b""
+
+        if n == -1 or n >= len(self.buffer):
+            result = self.buffer
+            self.buffer = b""
+        else:
+            result = self.buffer[:n]
+            self.buffer = self.buffer[n:]
+        return result
+
+    def _format_row(self, row):
+        formatted = []
+        for field in self.bq_schema:
+            val = row[field.name]
+            if val is None:
+                formatted.append("")
+            elif field.mode == "REPEATED":
+                # Convert list to Postgres array literal: {"val1", "val2"}
+                inner = [str(x) if not isinstance(x, str) else x for x in val]
+                escaped = []
+                for x in inner:
+                    x_str = str(x).replace('"', '\\"')
+                    escaped.append(f'"{x_str}"')
+                formatted.append(f'{{{",".join(escaped)}}}')
+            elif field.field_type == "BOOLEAN":
+                formatted.append("true" if val else "false")
+            else:
+                formatted.append(str(val))
+        return "\t".join(formatted)
 
 
 def get_pg_type(field):
@@ -31,188 +81,94 @@ def get_pg_type(field):
     return pg_type
 
 
-def get_all_sync_states(pg_conn):
-    """Gets the current sync state for all tables and datasets."""
+def get_all_sync_states(cursor):
+    """Gets the current sync state for all tables and datasets from Postgres."""
     states = {}
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS sync_state (
-                    table_name TEXT NOT NULL,
-                    dataset_id TEXT NOT NULL,
-                    last_synced_at TIMESTAMP WITHOUT TIME ZONE,
-                    PRIMARY KEY (table_name, dataset_id)
-                );
-            """
-            )
-            cursor.execute(
-                "SELECT table_name, dataset_id, last_synced_at FROM sync_state"
-            )
-            for table_name, dataset_id, last_synced_at in cursor.fetchall():
-                if table_name not in states:
-                    states[table_name] = {}
-                states[table_name][dataset_id] = last_synced_at
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sync_state (
+            table_name TEXT NOT NULL,
+            dataset_id TEXT NOT NULL,
+            last_synced_at TIMESTAMP WITHOUT TIME ZONE,
+            PRIMARY KEY (table_name, dataset_id)
+        );
+    """
+    )
+    cursor.execute("SELECT table_name, dataset_id, last_synced_at FROM sync_state")
+    for table_name, dataset_id, last_synced_at in cursor.fetchall():
+        if table_name not in states:
+            states[table_name] = {}
+        states[table_name][dataset_id] = last_synced_at
     return states
 
 
-def get_bq_latest_timestamps(bq_client, bq_dataset, bq_table, bq_location):
-    """Gets the latest max_ingested_at for every dataset_id in a BQ table."""
+def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_location):
+    """Gets the latest max_ingested_at and row count for every dataset_id in a BQ table."""
     query = f"""
-        SELECT dataset_id, MAX(max_ingested_at) as latest_ts
+        SELECT dataset_id, MAX(max_ingested_at) as latest_ts, COUNT(*) as row_count
         FROM `{bq_dataset}.{bq_table}`
         GROUP BY dataset_id
     """
     query_job = bq_client.query(query, location=bq_location)
     results = query_job.result()
-    return {row.dataset_id: row.latest_ts for row in results}
+    return {row.dataset_id: (row.latest_ts, row.row_count) for row in results}
 
 
-def export_bq_to_gcs(
-    bq_client,
-    bq_dataset,
-    bq_table,
-    bq_location,
-    gcs_bucket,
-    gcs_file_path_prefix,
-    dataset_ids,
-):
-    """Exports specific datasets from BigQuery to GCS in Parquet format."""
-    dataset_ref = bq_client.dataset(bq_dataset)
-    destination_uri = f"gs://{gcs_bucket}/{gcs_file_path_prefix}-*.parquet"
+def stream_bq_to_pg(cursor, pg_table, bq_client, bq_query, bq_schema, total_rows):
+    """Streams data from a BQ query directly into a Postgres table using COPY."""
+    query_job = bq_client.query(bq_query)
+    row_iterator = query_job.result()
 
-    job_config = bigquery.ExtractJobConfig(destination_format="PARQUET")
-
-    # Query to a temporary table, then export.
-    temp_table_id = f"temp_export_{uuid.uuid4().hex}"
-    temp_table_ref = dataset_ref.table(temp_table_id)
-
-    # Convert dataset_ids to a SQL-compatible list
-    dataset_ids_str = ", ".join([f"'{ds}'" for ds in dataset_ids])
-    query = f"""
-    SELECT *
-    FROM `{bq_dataset}.{bq_table}`
-    WHERE dataset_id IN ({dataset_ids_str})
-    """
-    query_job_config = bigquery.QueryJobConfig(destination=temp_table_ref)
-
-    query_job = bq_client.query(
-        query, job_config=query_job_config, location=bq_location
-    )
-    query_job.result()  # Wait for the query to finish
-
-    extract_job = bq_client.extract_table(
-        temp_table_ref,
-        destination_uri,
-        location=bq_location,
-        job_config=job_config,
-    )
-    extract_job.result()  # Wait for the extract to finish
-
-    bq_client.delete_table(temp_table_ref)  # Clean up temp table
-    return destination_uri
+    with tqdm(
+        total=total_rows, desc=f"  Loading rows to {pg_table}", leave=False
+    ) as pbar:
+        stream = BQRowIteratorIO(row_iterator, bq_schema, pbar=pbar)
+        cursor.copy_expert(
+            sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
+                sql.Identifier(pg_table)
+            ),
+            stream,
+        )
 
 
-def format_row(row, schema):
-    formatted = []
-    for i, field in enumerate(schema):
-        val = row[i]
-        if val is None:
-            formatted.append("")
-        elif field.mode == "REPEATED":
-            inner = [str(x) if not isinstance(x, str) else x for x in val]
-            escaped = []
-            for x in inner:
-                x_str = str(x).replace('"', '\\"')
-                escaped.append(f'"{x_str}"')
-            formatted.append(f'{{{",".join(escaped)}}}')
-        elif field.field_type == "BOOLEAN":
-            formatted.append("true" if val else "false")
-        else:
-            formatted.append(str(val))
-    return "\t".join(formatted)
-
-
-def load_parquet_to_pg(cursor, pg_table, gcs_bucket, gcs_file_path_prefix, schema):
-    """Loads parquet shards from GCS into Postgres using COPY."""
-    gcs_client = storage.Client()
-    bucket = gcs_client.get_bucket(gcs_bucket)
-    blobs = list(bucket.list_blobs(prefix=gcs_file_path_prefix))
-
-    for blob in tqdm(blobs, desc=f"Loading shards to {pg_table}", leave=False):
-        with blob.open("rb") as f:
-            parquet_file = pq.ParquetFile(f)
-            for i in range(parquet_file.num_row_groups):
-                table = parquet_file.read_row_group(i)
-                rows = table.to_pylist()
-
-                tsv_data = io.StringIO()
-                for row_dict in rows:
-                    row_val = [row_dict.get(field.name) for field in schema]
-                    tsv_data.write(format_row(row_val, schema) + "\n")
-
-                tsv_data.seek(0)
-                cursor.copy_expert(
-                    sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
-                        sql.Identifier(pg_table)
-                    ),
-                    tsv_data,
-                )
-
-
-def update_sync_state(pg_conn, pg_table, dataset_id, timestamp):
-    """Updates or inserts the sync state for a specific dataset."""
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                """
-                INSERT INTO sync_state (table_name, dataset_id, last_synced_at)
-                VALUES (%s, %s, %s)
-                ON CONFLICT (table_name, dataset_id) DO UPDATE
-                SET last_synced_at = EXCLUDED.last_synced_at;
-            """,
-                (pg_table, dataset_id, timestamp),
-            )
-
-
-def delete_dataset_from_pg(pg_conn, pg_table, dataset_id):
+def delete_dataset_from_pg(cursor, pg_table, dataset_id):
     """Deletes all rows for a given dataset_id from a Postgres table."""
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                sql.SQL("DELETE FROM {} WHERE dataset_id = %s").format(
-                    sql.Identifier(pg_table)
-                ),
-                (dataset_id,),
-            )
+    cursor.execute(
+        sql.SQL("DELETE FROM {} WHERE dataset_id = %s").format(
+            sql.Identifier(pg_table)
+        ),
+        (dataset_id,),
+    )
 
 
-def ensure_pg_table_exists(pg_conn, pg_table, bq_schema):
+def update_sync_state(cursor, pg_table, dataset_id, timestamp):
+    """Updates or inserts the sync state for a specific dataset."""
+    cursor.execute(
+        """
+        INSERT INTO sync_state (table_name, dataset_id, last_synced_at)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (table_name, dataset_id) DO UPDATE
+        SET last_synced_at = EXCLUDED.last_synced_at;
+    """,
+        (pg_table, dataset_id, timestamp),
+    )
+
+
+def ensure_pg_table_exists(cursor, pg_table, bq_schema):
     """Ensures the target table exists in Postgres, creating it if necessary."""
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
-                (pg_table,),
+    cursor.execute(
+        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
+        (pg_table,),
+    )
+    if not cursor.fetchone()[0]:
+        logging.info(f"Table {pg_table} does not exist. Creating.")
+        columns = [f"{field.name} {get_pg_type(field)}" for field in bq_schema]
+        cursor.execute(
+            sql.SQL("CREATE TABLE {} ({})").format(
+                sql.Identifier(pg_table),
+                sql.SQL(", ").join(map(sql.SQL, columns)),
             )
-            if not cursor.fetchone()[0]:
-                logging.info(f"Table {pg_table} does not exist. Creating.")
-                columns = [f"{field.name} {get_pg_type(field)}" for field in bq_schema]
-                cursor.execute(
-                    sql.SQL("CREATE TABLE {} ({})").format(
-                        sql.Identifier(pg_table),
-                        sql.SQL(", ").join(map(sql.SQL, columns)),
-                    )
-                )
-
-
-def cleanup_gcs(gcs_bucket, gcs_file_path_prefix):
-    """Removes temporary files from GCS."""
-    gcs_client = storage.Client()
-    bucket = gcs_client.get_bucket(gcs_bucket)
-    blobs = list(bucket.list_blobs(prefix=gcs_file_path_prefix))
-    for blob in blobs:
-        blob.delete()
+        )
 
 
 def main():
@@ -222,7 +178,6 @@ def main():
     parser.add_argument("--bq-location", required=True)
     parser.add_argument("--pg-conn", required=True)
     parser.add_argument("--pg-table", required=True)
-    parser.add_argument("--gcs-bucket", required=True)
     parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
     )
@@ -230,107 +185,133 @@ def main():
 
     bq_client = bigquery.Client()
 
-    # 1. Fetch current sync states
-    logging.info("Fetching current sync states from Postgres...")
-    all_states = get_all_sync_states(args.pg_conn)
-    current_table_states = all_states.get(args.pg_table, {})
+    try:
+        with psycopg2.connect(args.pg_conn) as conn:
+            with conn.cursor() as cursor:
+                # 1. Fetch current sync states
+                logging.info("Fetching current sync states from Postgres...")
+                all_states = get_all_sync_states(cursor)
+                current_table_states = all_states.get(args.pg_table, {})
 
-    # 2. Fetch latest timestamps from BQ
-    logging.info(f"Fetching latest dataset timestamps from BQ table {args.bq_table}...")
-    bq_latest = get_bq_latest_timestamps(
-        bq_client, args.bq_dataset, args.bq_table, args.bq_location
-    )
+                # 2. Fetch latest timestamps and counts from BQ
+                logging.info(
+                    f"Fetching latest dataset info from BQ table {args.bq_table}..."
+                )
+                bq_info = get_bq_latest_timestamps_and_counts(
+                    bq_client, args.bq_dataset, args.bq_table, args.bq_location
+                )
 
-    # 3. Determine datasets to process
-    to_update = []  # Exists in PG but timestamp in BQ is newer
-    to_insert = []  # Does not exist in PG
+                # 3. Determine datasets to process
+                to_update = []  # Exists in PG but timestamp in BQ is newer
+                to_insert = []  # Does not exist in PG
 
-    for ds_id, bq_ts in bq_latest.items():
-        if ds_id in current_table_states:
-            pg_ts = current_table_states[ds_id]
-            # BQ timestamp is offset-aware usually, but let's be careful.
-            # Comparison assumes both are comparable.
-            if pg_ts is None or bq_ts > pg_ts.replace(tzinfo=bq_ts.tzinfo):
-                to_update.append(ds_id)
-        else:
-            to_insert.append(ds_id)
+                for ds_id, (bq_ts, _) in bq_info.items():
+                    if ds_id in current_table_states:
+                        pg_ts = current_table_states[ds_id]
+                        if pg_ts is None or bq_ts > pg_ts.replace(tzinfo=bq_ts.tzinfo):
+                            to_update.append(ds_id)
+                    else:
+                        to_insert.append(ds_id)
 
-    # 4. Summary and confirmation
-    total_to_process = len(to_update) + len(to_insert)
-    if total_to_process == 0:
-        logging.info("Everything is up to date. Nothing to sync.")
-        return
+                # 4. Summary and confirmation
+                total_to_process = len(to_update) + len(to_insert)
+                if total_to_process == 0:
+                    logging.info("Everything is up to date. Nothing to sync.")
+                    return
 
-    print("\n--- Sync Summary ---")
-    print(f"Table: {args.pg_table}")
-    print(f"Datasets to update (delete + re-ingest): {len(to_update)}")
-    if to_update:
-        print(f"  {', '.join(to_update[:10])}{'...' if len(to_update) > 10 else ''}")
-    print(f"Datasets to insert (new): {len(to_insert)}")
-    if to_insert:
-        print(f"  {', '.join(to_insert[:10])}{'...' if len(to_insert) > 10 else ''}")
-    print(f"Total datasets to process: {total_to_process}")
-    print("--------------------\n")
-
-    if not args.yes:
-        confirm = input("Proceed with sync? (y/N): ")
-        if confirm.lower() != "y":
-            logging.info("Sync cancelled by user.")
-            sys.exit(0)
-
-    # 5. Execution
-    bq_table_obj = bq_client.get_table(f"{args.bq_dataset}.{args.bq_table}")
-    ensure_pg_table_exists(args.pg_conn, args.pg_table, bq_table_obj.schema)
-
-    all_to_process = sorted(to_update + to_insert)
-    # We process in chunks to avoid massive GCS exports if many datasets
-    chunk_size = 10  # Tuneable
-
-    pbar = tqdm(total=len(all_to_process), desc="Synchronizing datasets")
-
-    for i in range(0, len(all_to_process), chunk_size):
-        chunk = all_to_process[i : i + chunk_size]
-        gcs_prefix = f"tmp/{args.bq_dataset}_{args.bq_table}_{uuid.uuid4()}"
-
-        try:
-            # Delete if update
-            for ds_id in chunk:
-                if ds_id in to_update:
-                    delete_dataset_from_pg(args.pg_conn, args.pg_table, ds_id)
-
-            # Export chunk to GCS
-            export_bq_to_gcs(
-                bq_client,
-                args.bq_dataset,
-                args.bq_table,
-                args.bq_location,
-                args.gcs_bucket,
-                gcs_prefix,
-                chunk,
-            )
-
-            # Load to Postgres
-            with psycopg2.connect(args.pg_conn) as conn:
-                with conn.cursor() as cursor:
-                    load_parquet_to_pg(
-                        cursor,
-                        args.pg_table,
-                        args.gcs_bucket,
-                        gcs_prefix,
-                        bq_table_obj.schema,
+                print("\n--- Sync Summary ---")
+                print(f"Table: {args.pg_table}")
+                print(f"Datasets to update (delete + re-ingest): {len(to_update)}")
+                if to_update:
+                    print(
+                        f"  {', '.join(to_update[:10])}{'...' if len(to_update) > 10 else ''}"
                     )
+                print(f"Datasets to insert (new): {len(to_insert)}")
+                if to_insert:
+                    print(
+                        f"  {', '.join(to_insert[:10])}{'...' if len(to_insert) > 10 else ''}"
+                    )
+                print(f"Total datasets to process: {total_to_process}")
+                print("--------------------\n")
 
-            # Update sync states
-            for ds_id in chunk:
-                update_sync_state(args.pg_conn, args.pg_table, ds_id, bq_latest[ds_id])
+                if not args.yes:
+                    try:
+                        confirm = input("Proceed with sync? (y/N): ")
+                    except EOFError:
+                        confirm = "n"
+                    if confirm.lower() != "y":
+                        logging.info("Sync cancelled by user.")
+                        sys.exit(0)
 
-            pbar.update(len(chunk))
+                # 5. Execution
+                bq_table_obj = bq_client.get_table(f"{args.bq_dataset}.{args.bq_table}")
+                ensure_pg_table_exists(cursor, args.pg_table, bq_table_obj.schema)
 
-        finally:
-            cleanup_gcs(args.gcs_bucket, gcs_prefix)
+                all_to_process = sorted(to_update + to_insert)
+                chunk_size = 5
 
-    pbar.close()
-    logging.info("Sync completed successfully.")
+                overall_pbar = tqdm(
+                    total=len(all_to_process), desc="Synchronizing datasets"
+                )
+
+                for i in range(0, len(all_to_process), chunk_size):
+                    chunk = all_to_process[i : i + chunk_size]
+                    chunk_rows = sum([bq_info[ds_id][1] for ds_id in chunk])
+
+                    try:
+                        # Delete if update
+                        for ds_id in chunk:
+                            if ds_id in to_update:
+                                delete_dataset_from_pg(cursor, args.pg_table, ds_id)
+
+                        # Build query for the chunk
+                        ds_ids_str = ", ".join([f"'{ds}'" for ds in chunk])
+                        bq_query = f"""
+                            SELECT *
+                            FROM `{args.bq_dataset}.{args.bq_table}`
+                            WHERE dataset_id IN ({ds_ids_str})
+                        """
+
+                        # Stream directly from BQ to PG
+                        stream_bq_to_pg(
+                            cursor,
+                            args.pg_table,
+                            bq_client,
+                            bq_query,
+                            bq_table_obj.schema,
+                            chunk_rows,
+                        )
+
+                        # Update sync states
+                        for ds_id in chunk:
+                            update_sync_state(
+                                cursor, args.pg_table, ds_id, bq_info[ds_id][0]
+                            )
+
+                        # COMMIT EACH CHUNK
+                        conn.commit()
+                        overall_pbar.update(len(chunk))
+
+                    except (Exception, KeyboardInterrupt) as e:
+                        conn.rollback()
+                        overall_pbar.close()
+                        if isinstance(e, KeyboardInterrupt):
+                            logging.error(
+                                "\nSync interrupted by user. Rolling back current chunk..."
+                            )
+                        else:
+                            logging.error(f"\nError during sync: {e}. Rolling back...")
+                        sys.exit(1)
+
+                overall_pbar.close()
+                logging.info("Sync completed successfully.")
+
+    except psycopg2.Error as e:
+        logging.error(f"Postgres connection error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logging.info("\nExiting...")
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -101,12 +101,6 @@ def get_all_sync_states(cursor):
         );
     """
     )
-    cursor.execute("SELECT table_name, dataset_id, last_synced_at FROM sync_state")
-    for table_name, dataset_id, last_synced_at in cursor.fetchall():
-        if table_name not in states:  # Bug here in previous version, fixing.
-            pass  # Actually 'states' is local here.
-
-    # Corrected implementation:
     states = {}
     cursor.execute("SELECT table_name, dataset_id, last_synced_at FROM sync_state")
     for table_name, dataset_id, last_synced_at in cursor.fetchall():

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -3,14 +3,12 @@ import logging
 import io
 import sys
 import uuid
-import threading
-import queue
-
-from google.cloud import bigquery
+from google.cloud import bigquery, storage
 import psycopg2
 from psycopg2 import sql
 from tqdm import tqdm
-import pyarrow.csv as pacsv
+import pyarrow.parquet as pq
+
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -20,82 +18,6 @@ TABLES_TO_SYNC = [
     "perturb_seq_dea",
     "perturb_seq_gsea",
 ]
-
-
-class BQToPGStream(io.RawIOBase):
-    """
-    High-performance stream that buffers Arrow batches from BQ (Producer)
-    and serves them in TSV format to Postgres COPY (Consumer).
-    """
-
-    def __init__(self, bq_client, temp_table_id, bq_schema, pbar=None):
-        self.bq_client = bq_client
-        self.temp_table_id = temp_table_id
-        self.bq_schema = bq_schema
-        self.pbar = pbar
-
-        self.queue = queue.Queue(maxsize=10)  # Buffer up to 10 batches
-        self.buffer = b""
-        self.finished = False
-        self.error = None
-
-        # Start the background producer thread
-        self.thread = threading.Thread(target=self._producer)
-        self.thread.daemon = True
-        self.thread.start()
-
-    def readable(self):
-        return True
-
-    def _producer(self):
-        """Background thread to fetch data from BigQuery and serialize to TSV."""
-        try:
-            # Fetch data in Arrow record batches
-            row_iterator = self.bq_client.list_rows(self.temp_table_id)
-            arrow_batches = row_iterator.to_arrow_iterable()
-
-            write_options = pacsv.WriteOptions(
-                include_header=False, delimiter="\t", quoting_style="none"
-            )
-
-            for batch in arrow_batches:
-                # Serialize the entire batch to TSV in-memory using C-based pyarrow
-                out = io.BytesIO()
-                pacsv.write_csv(batch, out, write_options=write_options)
-                tsv_chunk = out.getvalue()
-
-                self.queue.put(tsv_chunk)
-
-                if self.pbar:
-                    self.pbar.update(batch.num_rows)
-
-            self.queue.put(None)  # Sentinel for completion
-        except Exception as e:
-            self.error = e
-            self.queue.put(None)
-
-    def read(self, n=-1):
-        if self.error:
-            raise self.error
-
-        while not self.buffer:
-            if self.finished:
-                return b""
-
-            chunk = self.queue.get()
-            if chunk is None:
-                self.finished = True
-                continue
-
-            self.buffer = chunk
-
-        if n == -1 or n >= len(self.buffer):
-            result = self.buffer
-            self.buffer = b""
-        else:
-            result = self.buffer[:n]
-            self.buffer = self.buffer[n:]
-        return result
 
 
 def get_pg_type(field):
@@ -149,48 +71,108 @@ def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_loca
     return {row.dataset_id: (row.latest_ts, row.row_count) for row in results}
 
 
-def stream_bq_to_pg(
-    cursor,
-    pg_table,
-    bq_client,
-    bq_dataset,
-    bq_table,
-    bq_location,
-    dataset_id,
-    bq_schema,
-    total_rows,
-):
-    """High-performance stream from BQ to PG using Arrow, threading, and bulk serialization."""
-    temp_table_id = f"{bq_client.project}.{bq_dataset}.temp_sync_{uuid.uuid4().hex}"
+def format_row(row, schema):
+    """Formats a row for Postgres COPY command (TSV)."""
+    formatted = []
+    for i, field in enumerate(schema):
+        val = row[i]
+        if val is None:
+            formatted.append("")
+        elif field.mode == "REPEATED":
+            # Convert list to Postgres array literal: {"val1", "val2"}
+            inner = [str(x) if not isinstance(x, str) else x for x in val]
+            escaped = []
+            for x in inner:
+                x_str = str(x).replace('"', '\\"')
+                escaped.append(f'"{x_str}"')
+            formatted.append(f'{{{",".join(escaped)}}}')
+        elif field.field_type == "BOOLEAN":
+            formatted.append("true" if val else "false")
+        else:
+            formatted.append(str(val))
+    return "\t".join(formatted)
 
-    job_config = bigquery.QueryJobConfig(
-        destination=temp_table_id,
-        write_disposition="WRITE_TRUNCATE",
-    )
+
+def export_dataset_to_gcs(
+    bq_client, bq_dataset, bq_table, bq_location, gcs_bucket, gcs_prefix, dataset_id
+):
+    """Exports a specific dataset from BigQuery to GCS as Parquet."""
+    destination_uri = f"gs://{gcs_bucket}/{gcs_prefix}-*.parquet"
+    dataset_ref = bq_client.dataset(bq_dataset)
+
+    # Query to a temporary table to filter by dataset_id
+    temp_table_id = f"temp_sync_{uuid.uuid4().hex}"
+    temp_table_ref = dataset_ref.table(temp_table_id)
 
     query = f"SELECT * FROM `{bq_dataset}.{bq_table}` WHERE dataset_id = '{dataset_id}'"
+    job_config = bigquery.QueryJobConfig(destination=temp_table_ref)
 
-    # query_job = bq_client.query(query, job_config=job_config, location=bq_location)
-    # query_job.result() # Wait for completion
+    query_job = None
+    extract_job = None
 
-    # Fetching the query results to a temp table is still needed for huge results scalability
-    query_job = bq_client.query(query, job_config=job_config, location=bq_location)
-    query_job.result()
+    try:
+        query_job = bq_client.query(query, job_config=job_config, location=bq_location)
+        query_job.result()
 
-    with tqdm(
-        total=total_rows, desc=f"    Syncing {dataset_id}", leave=False, unit="rows"
-    ) as pbar:
-        # Use our high-performance asynchronous stream
-        stream = BQToPGStream(bq_client, temp_table_id, bq_schema, pbar=pbar)
-        cursor.copy_expert(
-            sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
-                sql.Identifier(pg_table)
-            ),
-            stream,
+        # Extract temp table to GCS
+        extract_config = bigquery.ExtractJobConfig(destination_format="PARQUET")
+        extract_job = bq_client.extract_table(
+            temp_table_ref,
+            destination_uri,
+            location=bq_location,
+            job_config=extract_config,
         )
+        extract_job.result()
+    except (Exception, KeyboardInterrupt) as e:
+        if query_job and not query_job.done():
+            logging.info("        Cancelling BigQuery query job...")
+            query_job.cancel()
+        if extract_job and not extract_job.done():
+            logging.info("        Cancelling BigQuery extract job...")
+            extract_job.cancel()
+        raise e
+    finally:
+        # Clean up temp table
+        bq_client.delete_table(temp_table_ref, not_found_ok=True)
 
-    # Clean up temp table
-    bq_client.delete_table(temp_table_id, not_found_ok=True)
+    return destination_uri
+
+
+def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
+    """Loads Parquet files from GCS into Postgres using COPY."""
+    gcs_client = storage.Client()
+    bucket = gcs_client.get_bucket(gcs_bucket)
+    blobs = list(bucket.list_blobs(prefix=gcs_prefix))
+
+    for blob in tqdm(blobs, desc="        Loading shards", leave=False):
+        with blob.open("rb") as f:
+            parquet_file = pq.ParquetFile(f)
+            for i in range(parquet_file.num_row_groups):
+                table = parquet_file.read_row_group(i)
+                rows = table.to_pylist()
+
+                tsv_data = io.StringIO()
+                for row_dict in rows:
+                    row_val = [row_dict.get(field.name) for field in bq_schema]
+                    tsv_data.write(format_row(row_val, bq_schema) + "\n")
+
+                tsv_data.seek(0)
+                cursor.copy_expert(
+                    sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
+                        sql.Identifier(pg_table)
+                    ),
+                    tsv_data,
+                )
+
+
+def cleanup_gcs(gcs_bucket, gcs_prefix):
+    """Removes temporary files from GCS."""
+    logging.info(f"      - Cleaning up GCS files...")
+    gcs_client = storage.Client()
+    bucket = gcs_client.get_bucket(gcs_bucket)
+    blobs = list(bucket.list_blobs(prefix=gcs_prefix))
+    for blob in blobs:
+        blob.delete()
 
 
 def delete_dataset_from_pg(cursor, pg_table, dataset_id):
@@ -238,6 +220,7 @@ def main():
     parser.add_argument("--bq-dataset", required=True)
     parser.add_argument("--bq-location", required=True)
     parser.add_argument("--pg-conn", required=True)
+    parser.add_argument("--gcs-bucket", required=True)
     parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
     )
@@ -339,18 +322,34 @@ def main():
                             if ds_id in plan["to_update"]:
                                 delete_dataset_from_pg(cursor, table_name, ds_id)
 
-                            # High-performance streaming
-                            stream_bq_to_pg(
-                                cursor,
-                                table_name,
-                                bq_client,
-                                args.bq_dataset,
-                                table_name,
-                                args.bq_location,
-                                ds_id,
-                                bq_table_obj.schema,
-                                row_count,
-                            )
+                            # Parquet-based sync via GCS
+                            gcs_prefix = f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
+                            logging.info(f"    Processing {ds_id}:")
+
+                            try:
+                                logging.info(
+                                    f"      - Exporting from BigQuery to GCS..."
+                                )
+                                export_dataset_to_gcs(
+                                    bq_client,
+                                    args.bq_dataset,
+                                    table_name,
+                                    args.bq_location,
+                                    args.gcs_bucket,
+                                    gcs_prefix,
+                                    ds_id,
+                                )
+
+                                logging.info(f"      - Loading from GCS to Postgres...")
+                                load_parquet_from_gcs_to_pg(
+                                    cursor,
+                                    table_name,
+                                    args.gcs_bucket,
+                                    gcs_prefix,
+                                    bq_table_obj.schema,
+                                )
+                            finally:
+                                cleanup_gcs(args.gcs_bucket, gcs_prefix)
 
                             # Update sync states
                             update_sync_state(cursor, table_name, ds_id, bq_timestamp)

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -186,7 +186,7 @@ def _convert_array_column(col):
             escaped = []
             for x in val:
                 x_str = str(x).replace("\\", "\\\\").replace('"', '\\"')
-                escaped.append(f'"{ x_str}"')
+                escaped.append(f'"{x_str}"')
             result.append("{" + ",".join(escaped) + "}")
     return pa.array(result, type=pa.string())
 
@@ -247,9 +247,9 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
 
-    copy_sql = sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
-        sql.Identifier(pg_table)
-    )
+    copy_sql = sql.SQL(
+        "COPY {} FROM STDIN WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\"', NULL '')"
+    ).format(sql.Identifier(pg_table))
 
     max_workers = GCS_DOWNLOAD_WORKERS
     blob_iter = iter(blobs)

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -19,6 +19,53 @@ TABLES_TO_SYNC = [
     "perturb_seq_gsea",
 ]
 
+INDEX_DEFINITIONS = {
+    "perturb_seq_dea": [
+        (
+            "idx_perturbation_dea",
+            "CREATE INDEX idx_perturbation_dea ON public.perturb_seq_dea (perturbed_target_symbol, dataset_id, padj, score_value, log2foldchange)",
+        ),
+        (
+            "idx_phenotype_dea",
+            "CREATE INDEX idx_phenotype_dea ON public.perturb_seq_dea (gene, dataset_id, padj, score_value, log2foldchange)",
+        ),
+        (
+            "idx_perturbation_phenotype_dea",
+            "CREATE INDEX idx_perturbation_phenotype_dea ON public.perturb_seq_dea (perturbed_target_symbol, gene, dataset_id, padj, score_value, log2foldchange)",
+        ),
+        (
+            "idx_perturb_seq_dea_dataset_id_padj",
+            "CREATE INDEX idx_perturb_seq_dea_dataset_id_padj ON public.perturb_seq_dea (dataset_id, padj) WHERE gene IS NOT NULL",
+        ),
+    ],
+    "perturb_seq_gsea": [
+        (
+            "idx_perturbation_gsea",
+            "CREATE INDEX idx_perturbation_gsea ON public.perturb_seq_gsea (perturbed_target_symbol, dataset_id, fdr, nes)",
+        ),
+    ],
+    "crispr_data": [
+        (
+            "idx_crispr_data_dataset",
+            "CREATE INDEX idx_crispr_data_dataset ON public.crispr_data (dataset_id)",
+        ),
+        (
+            "idx_crispr_data_target",
+            "CREATE INDEX idx_crispr_data_target ON public.crispr_data (perturbed_target_symbol)",
+        ),
+    ],
+    "mave_data": [
+        (
+            "idx_mave_data_dataset",
+            "CREATE INDEX idx_mave_data_dataset ON public.mave_data (dataset_id)",
+        ),
+        (
+            "idx_mave_data_target",
+            "CREATE INDEX idx_mave_data_target ON public.mave_data (perturbed_target_symbol, dataset_id)",
+        ),
+    ],
+}
+
 
 def get_pg_type(field):
     """Maps BigQuery types to PostgreSQL types."""
@@ -215,6 +262,28 @@ def ensure_pg_table_exists(cursor, pg_table, bq_schema):
         )
 
 
+def drop_indexes(cursor, table_name):
+    """Drops all indexes for a given table based on INDEX_DEFINITIONS."""
+    if table_name not in INDEX_DEFINITIONS:
+        return
+    logging.info(f"      - Dropping indexes for {table_name}...")
+    for index_name, _ in INDEX_DEFINITIONS[table_name]:
+        cursor.execute(
+            sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(index_name))
+        )
+
+
+def create_indexes(cursor, table_name):
+    """Creates all indexes for a given table based on INDEX_DEFINITIONS."""
+    if table_name not in INDEX_DEFINITIONS:
+        return
+    logging.info(
+        f"      - Reinstating indexes for {table_name} (this may take a while)..."
+    )
+    for _, index_sql in INDEX_DEFINITIONS[table_name]:
+        cursor.execute(index_sql)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bq-dataset", required=True)
@@ -311,6 +380,9 @@ def main():
                     )
                     ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
 
+                    # Drop indexes before bulk update
+                    drop_indexes(cursor, table_name)
+
                     all_to_process = sorted(plan["to_update"] + plan["to_insert"])
 
                     for ds_id in all_to_process:
@@ -354,8 +426,6 @@ def main():
                             # Update sync states
                             update_sync_state(cursor, table_name, ds_id, bq_timestamp)
 
-                            # COMMIT EVERY DATASET
-                            conn.commit()
                             overall_pbar.update(1)
 
                         except (Exception, KeyboardInterrupt) as e:
@@ -370,6 +440,12 @@ def main():
                                     f"\nError syncing {table_name}/{ds_id}: {e}. Rolling back..."
                                 )
                             sys.exit(1)
+
+                    # Rebuild indexes after all data for this table is loaded
+                    create_indexes(cursor, table_name)
+
+                    # COMMIT ONCE PER TABLE
+                    conn.commit()
 
                 overall_pbar.close()
                 logging.info("Multi-table sync completed successfully.")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -368,6 +368,11 @@ def main():
     parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
     )
+    parser.add_argument(
+        "--drop-and-recreate-indexes",
+        action="store_true",
+        help="Drop indexes before loading and recreate them after (faster for bulk loads)",
+    )
     args = parser.parse_args()
 
     bq_client = bigquery.Client()
@@ -455,8 +460,9 @@ def main():
                     )
                     ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
 
-                    # Drop indexes before bulk update
-                    drop_indexes(cursor, table_name)
+                    # Drop indexes before bulk update (if requested)
+                    if args.drop_and_recreate_indexes:
+                        drop_indexes(cursor, table_name)
 
                     all_to_process = sorted(plan["to_update"] + plan["to_insert"])
 
@@ -517,7 +523,8 @@ def main():
                             sys.exit(1)
 
                     # Rebuild indexes after all data for this table is loaded
-                    create_indexes(cursor, table_name)
+                    if args.drop_and_recreate_indexes:
+                        create_indexes(cursor, table_name)
 
                     # COMMIT ONCE PER TABLE
                     conn.commit()

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -3,11 +3,14 @@ import logging
 import io
 import sys
 import uuid
+import threading
+import queue
 
 from google.cloud import bigquery
 import psycopg2
 from psycopg2 import sql
 from tqdm import tqdm
+import pyarrow.csv as pacsv
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -19,28 +22,72 @@ TABLES_TO_SYNC = [
 ]
 
 
-class BQRowIteratorIO(io.RawIOBase):
-    """File-like object that streams rows from a BigQuery iterator in TSV format."""
+class BQToPGStream(io.RawIOBase):
+    """
+    High-performance stream that buffers Arrow batches from BQ (Producer)
+    and serves them in TSV format to Postgres COPY (Consumer).
+    """
 
-    def __init__(self, row_iterator, bq_schema, pbar=None):
-        self.row_iterator = row_iterator
+    def __init__(self, bq_client, temp_table_id, bq_schema, pbar=None):
+        self.bq_client = bq_client
+        self.temp_table_id = temp_table_id
         self.bq_schema = bq_schema
-        self.buffer = b""
         self.pbar = pbar
+
+        self.queue = queue.Queue(maxsize=10)  # Buffer up to 10 batches
+        self.buffer = b""
+        self.finished = False
+        self.error = None
+
+        # Start the background producer thread
+        self.thread = threading.Thread(target=self._producer)
+        self.thread.daemon = True
+        self.thread.start()
 
     def readable(self):
         return True
 
-    def read(self, n=-1):
-        while not self.buffer:
-            try:
-                row = next(self.row_iterator)
+    def _producer(self):
+        """Background thread to fetch data from BigQuery and serialize to TSV."""
+        try:
+            # Fetch data in Arrow record batches
+            row_iterator = self.bq_client.list_rows(self.temp_table_id)
+            arrow_batches = row_iterator.to_arrow_iterable()
+
+            write_options = pacsv.WriteOptions(
+                include_header=False, delimiter="\t", quoting_style="none"
+            )
+
+            for batch in arrow_batches:
+                # Serialize the entire batch to TSV in-memory using C-based pyarrow
+                out = io.BytesIO()
+                pacsv.write_csv(batch, out, write_options=write_options)
+                tsv_chunk = out.getvalue()
+
+                self.queue.put(tsv_chunk)
+
                 if self.pbar:
-                    self.pbar.update(1)
-                line = self._format_row(row) + "\n"
-                self.buffer = line.encode("utf-8")
-            except StopIteration:
+                    self.pbar.update(batch.num_rows)
+
+            self.queue.put(None)  # Sentinel for completion
+        except Exception as e:
+            self.error = e
+            self.queue.put(None)
+
+    def read(self, n=-1):
+        if self.error:
+            raise self.error
+
+        while not self.buffer:
+            if self.finished:
                 return b""
+
+            chunk = self.queue.get()
+            if chunk is None:
+                self.finished = True
+                continue
+
+            self.buffer = chunk
 
         if n == -1 or n >= len(self.buffer):
             result = self.buffer
@@ -49,26 +96,6 @@ class BQRowIteratorIO(io.RawIOBase):
             result = self.buffer[:n]
             self.buffer = self.buffer[n:]
         return result
-
-    def _format_row(self, row):
-        formatted = []
-        for field in self.bq_schema:
-            val = row[field.name]
-            if val is None:
-                formatted.append("")
-            elif field.mode == "REPEATED":
-                # Convert list to Postgres array literal: {"val1", "val2"}
-                inner = [str(x) if not isinstance(x, str) else x for x in val]
-                escaped = []
-                for x in inner:
-                    x_str = str(x).replace('"', '\\"')
-                    escaped.append(f'"{x_str}"')
-                formatted.append(f'{{{",".join(escaped)}}}')
-            elif field.field_type == "BOOLEAN":
-                formatted.append("true" if val else "false")
-            else:
-                formatted.append(str(val))
-        return "\t".join(formatted)
 
 
 def get_pg_type(field):
@@ -133,9 +160,7 @@ def stream_bq_to_pg(
     bq_schema,
     total_rows,
 ):
-    """Streams data from a large BQ query directly into a Postgres table using a temp destination table."""
-    # Use a destination table for the query result if it's potentially huge.
-    # To keep things robust, we'll ALWAYS use a destination table for dataset ingestion.
+    """High-performance stream from BQ to PG using Arrow, threading, and bulk serialization."""
     temp_table_id = f"{bq_client.project}.{bq_dataset}.temp_sync_{uuid.uuid4().hex}"
 
     job_config = bigquery.QueryJobConfig(
@@ -145,16 +170,18 @@ def stream_bq_to_pg(
 
     query = f"SELECT * FROM `{bq_dataset}.{bq_table}` WHERE dataset_id = '{dataset_id}'"
 
-    query_job = bq_client.query(query, job_config=job_config, location=bq_location)
-    query_job.result()  # Wait for completion
+    # query_job = bq_client.query(query, job_config=job_config, location=bq_location)
+    # query_job.result() # Wait for completion
 
-    # Fetch rows from the destination table. This avoids result size limits.
-    row_iterator = bq_client.list_rows(temp_table_id)
+    # Fetching the query results to a temp table is still needed for huge results scalability
+    query_job = bq_client.query(query, job_config=job_config, location=bq_location)
+    query_job.result()
 
     with tqdm(
-        total=total_rows, desc=f"    Loading {dataset_id}", leave=False, unit="rows"
+        total=total_rows, desc=f"    Syncing {dataset_id}", leave=False, unit="rows"
     ) as pbar:
-        stream = BQRowIteratorIO(row_iterator, bq_schema, pbar=pbar)
+        # Use our high-performance asynchronous stream
+        stream = BQToPGStream(bq_client, temp_table_id, bq_schema, pbar=pbar)
         cursor.copy_expert(
             sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
                 sql.Identifier(pg_table)
@@ -312,7 +339,7 @@ def main():
                             if ds_id in plan["to_update"]:
                                 delete_dataset_from_pg(cursor, table_name, ds_id)
 
-                            # Stream directly from BQ to PG using a temp destination table for safety
+                            # High-performance streaming
                             stream_bq_to_pg(
                                 cursor,
                                 table_name,

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -86,79 +86,18 @@ INDEX_DEFINITIONS = {
     ],
 }
 
-# Materialized view definitions.
-# Format: { base_table_name: [ (view_name, create_sql_template, [(index_name, index_sql_template), ...]), ... ] }
-MATERIALIZED_VIEW_DEFINITIONS = {
+# Names of materialized views to refresh for each table.
+# Definitions are no longer managed here (assumed to exist).
+TABLE_MATERIALIZED_VIEWS = {
     "perturb_seq_dea": [
-        (
-            "perturb_seq_summary_perturbation",
-            """CREATE MATERIALIZED VIEW {view} AS
-SELECT
-    dataset_id,
-    perturbed_target_symbol,
-    COUNT(*) AS n_total,
-    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
-    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up
-FROM {source_table}
-WHERE padj <= 0.05
-GROUP BY dataset_id, perturbed_target_symbol""",
-            [
-                (
-                    "idx_perturb_seq_summary_perturbation_pk",
-                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id, perturbed_target_symbol)",
-                ),
-            ],
-        ),
-        (
-            "perturb_seq_summary_effect",
-            """CREATE MATERIALIZED VIEW {view} AS
-SELECT
-    dataset_id,
-    gene,
-    COUNT(*) AS n_total,
-    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
-    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up,
-    AVG(score_value) AS avg_score
-FROM {source_table}
-WHERE padj <= 0.05
-GROUP BY dataset_id, gene""",
-            [
-                (
-                    "idx_perturb_seq_summary_effect_pk",
-                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id, gene)",
-                ),
-            ],
-        ),
-        (
-            "perturb_seq_summary_dataset",
-            """CREATE MATERIALIZED VIEW {view} AS
-SELECT
-    dataset_id,
-    COUNT(*) AS n_total
-FROM {source_table}
-WHERE gene IS NOT NULL
-GROUP BY dataset_id""",
-            [
-                (
-                    "idx_perturb_seq_summary_dataset_pk",
-                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id)",
-                ),
-            ],
-        ),
+        "perturb_seq_summary_perturbation",
+        "perturb_seq_summary_effect",
+        "perturb_seq_summary_dataset",
     ],
 }
 
 # Number of threads for concurrent GCS blob download + Parquet-to-CSV conversion.
 GCS_DOWNLOAD_WORKERS = os.cpu_count() or 4
-
-
-class IngestionMode(enum.Enum):
-    LIVE_NONBLOCKING = "live_nonblocking"
-    COPY_NONBLOCKING = "copy_nonblocking"
-    DIRECT_BLOCKING = "direct_blocking"
-
-    def __str__(self):
-        return self.value
 
 
 # ------------------------------------------------------------------------------
@@ -408,19 +347,6 @@ def ensure_pg_table_exists(cursor, pg_table, bq_schema):
         )
 
 
-def copy_table_schema(cursor, src_table, dst_table):
-    """Creates a dst_table with the same schema as src_table (no data, no indexes)."""
-    logging.info(f"      - Creating {dst_table} (copy of {src_table} schema)...")
-    cursor.execute(
-        sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(sql.Identifier(dst_table))
-    )
-    cursor.execute(
-        sql.SQL("CREATE TABLE {} (LIKE {})").format(
-            sql.Identifier(dst_table), sql.Identifier(src_table)
-        )
-    )
-
-
 def drop_indexes(cursor, table_name, suffix=""):
     """Drops all indexes for a given table based on INDEX_DEFINITIONS."""
     if table_name not in INDEX_DEFINITIONS:
@@ -448,39 +374,11 @@ def create_indexes(cursor, table_name, suffix=""):
         cursor.execute(index_sql)
 
 
-def create_materialized_views(cursor, table_name, suffix=""):
-    """Creates materialized views (with optional suffix) from definitions."""
-    if table_name not in MATERIALIZED_VIEW_DEFINITIONS:
-        return
-    for view_name, create_sql_template, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
-        table_name
-    ]:
-        view = f"{view_name}{suffix}"
-        source = f"{table_name}{suffix}"
-        logging.info(f"      - Creating materialized view {view}...")
-        cursor.execute(
-            sql.SQL("DROP MATERIALIZED VIEW IF EXISTS {}").format(sql.Identifier(view))
-        )
-        create_sql = create_sql_template.format(
-            view=sql.Identifier(view).as_string(cursor.connection),
-            source_table=sql.Identifier(source).as_string(cursor.connection),
-        )
-        cursor.execute(create_sql)
-        for mv_index_name, mv_index_sql_template in view_indexes:
-            idx = f"{mv_index_name}{suffix}"
-            logging.info(f"        Creating index {idx}...")
-            mv_index_sql = mv_index_sql_template.format(
-                idx=sql.Identifier(idx).as_string(cursor.connection),
-                view=sql.Identifier(view).as_string(cursor.connection),
-            )
-            cursor.execute(mv_index_sql)
-
-
 def refresh_materialized_views(cursor, table_name, concurrently=False):
     """Refreshes materialized views associated with the table."""
-    if table_name not in MATERIALIZED_VIEW_DEFINITIONS:
+    if table_name not in TABLE_MATERIALIZED_VIEWS:
         return
-    for view_name, _, _ in MATERIALIZED_VIEW_DEFINITIONS[table_name]:
+    for view_name in TABLE_MATERIALIZED_VIEWS[table_name]:
         logging.info(f"      - Refreshing materialized view {view_name}...")
         conc_clause = "CONCURRENTLY " if concurrently else ""
         try:
@@ -504,55 +402,6 @@ def refresh_materialized_views(cursor, table_name, concurrently=False):
                 )
 
 
-def swap_table(conn, table_name):
-    """Atomically swaps {table_name}_upd into {table_name}."""
-    upd = f"{table_name}_upd"
-    logging.info(f"      - Swapping {upd} -> {table_name} (atomic transaction)...")
-
-    with conn:
-        with conn.cursor() as cursor:
-            # 1. Drop original table (CASCADE drops dependent MVs)
-            cursor.execute(
-                sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
-                    sql.Identifier(table_name)
-                )
-            )
-            # 2. Rename _upd table
-            cursor.execute(
-                sql.SQL("ALTER TABLE {} RENAME TO {}").format(
-                    sql.Identifier(upd), sql.Identifier(table_name)
-                )
-            )
-            # 3. Rename indexes
-            if table_name in INDEX_DEFINITIONS:
-                for index_name, _ in INDEX_DEFINITIONS[table_name]:
-                    cursor.execute(
-                        sql.SQL("ALTER INDEX {} RENAME TO {}").format(
-                            sql.Identifier(f"{index_name}_upd"),
-                            sql.Identifier(index_name),
-                        )
-                    )
-            # 4. Rename MVs and their indexes
-            if table_name in MATERIALIZED_VIEW_DEFINITIONS:
-                for view_name, _, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
-                    table_name
-                ]:
-                    cursor.execute(
-                        sql.SQL("ALTER MATERIALIZED VIEW {} RENAME TO {}").format(
-                            sql.Identifier(f"{view_name}_upd"),
-                            sql.Identifier(view_name),
-                        )
-                    )
-                    for mv_index_name, _ in view_indexes:
-                        cursor.execute(
-                            sql.SQL("ALTER INDEX {} RENAME TO {}").format(
-                                sql.Identifier(f"{mv_index_name}_upd"),
-                                sql.Identifier(mv_index_name),
-                            )
-                        )
-    logging.info(f"      - Swap complete for {table_name}.")
-
-
 # ------------------------------------------------------------------------------
 # Core Logic Class
 # ------------------------------------------------------------------------------
@@ -561,13 +410,13 @@ def swap_table(conn, table_name):
 class TableSynchronizer:
     def __init__(
         self,
-        mode: IngestionMode,
+        drop_and_recreate_indexes: bool,
         pg_conn_str: str,
         bq_dataset: str,
         bq_location: str,
         gcs_bucket: str,
     ):
-        self.mode = mode
+        self.drop_and_recreate_indexes = drop_and_recreate_indexes
         self.pg_conn_str = pg_conn_str
         self.bq_dataset = bq_dataset
         self.bq_location = bq_location
@@ -575,15 +424,9 @@ class TableSynchronizer:
         self.bq_client = bigquery.Client()
 
     def sync_table(self, table_name: str, plan: Dict[str, Any]):
-        logging.info(f"Syncing table {table_name} in mode {self.mode}...")
+        logging.info(f"Syncing table {table_name}...")
         try:
-            if self.mode == IngestionMode.LIVE_NONBLOCKING:
-                self._sync_live_nonblocking(table_name, plan)
-            elif self.mode == IngestionMode.COPY_NONBLOCKING:
-                self._sync_copy_nonblocking(table_name, plan)
-            elif self.mode == IngestionMode.DIRECT_BLOCKING:
-                self._sync_direct_blocking(table_name, plan)
-
+            self._sync_unified(table_name, plan)
             logging.info(f"Successfully synced {table_name}.")
 
         except Exception as e:
@@ -620,31 +463,37 @@ class TableSynchronizer:
         finally:
             cleanup_gcs(self.gcs_bucket, gcs_prefix)
 
-    def _sync_live_nonblocking(self, table_name: str, plan: Dict[str, Any]):
+    def _sync_unified(self, table_name: str, plan: Dict[str, Any]):
         """
-        Mode 1: LIVE_NONBLOCKING
-        - Single transaction for all data updates (Delete + Insert).
-        - No table copying.
-        - No index dropping (updates are slower but non-blocking).
-        - Updates sync_state in same transaction.
-        - Refreshes MVs afterwards (concurrently if possible).
+        Unified Sync Mode:
+        - Single transaction for:
+            1. (Optional) Drop Indexes
+            2. Data Updates (Delete + Insert) for all datasets
+            3. (Optional) Recreate Indexes
+            4. Update sync_state
+        - (Separate) Refresh MVs concurrently.
         """
         bq_schema = self._get_bq_schema(table_name)
         datasets = sorted(plan["to_update"] + plan["to_insert"])
 
-        # 1. Data Update Transaction
+        # 1. Main Transaction Block
         with psycopg2.connect(self.pg_conn_str) as conn:
             with conn.cursor() as cursor:
                 ensure_pg_table_exists(cursor, table_name, bq_schema)
 
-                # Perform all updates in one transaction
                 logging.info(
-                    f"    Starting data update transaction for {len(datasets)} datasets..."
+                    f"    Starting transaction for {len(datasets)} datasets..."
                 )
+
+                # A. Drop Indexes (if requested)
+                if self.drop_and_recreate_indexes:
+                    drop_indexes(cursor, table_name)
+
+                # B. Ingest Loop
                 for ds_id in tqdm(
                     datasets, desc=f"    Syncing {table_name}", unit="dataset"
                 ):
-                    # Ingest data
+                    # Data Ingestion
                     self._ingest_dataset_logic(
                         cursor, table_name, table_name, ds_id, bq_schema
                     )
@@ -653,8 +502,12 @@ class TableSynchronizer:
                     bq_ts = plan["bq_info"][ds_id][0]
                     update_sync_state(cursor, table_name, ds_id, bq_ts)
 
-        # 2. Materialized View Refresh (outside transaction)
-        # We try CONCURRENTLY to be non-blocking.
+                # C. Recreate Indexes (if requested)
+                if self.drop_and_recreate_indexes:
+                    create_indexes(cursor, table_name)
+
+        # 2. Materialized View Refresh (concurrently, separate connection)
+        # Only if we successfully committed the transaction above.
         with psycopg2.connect(self.pg_conn_str) as conn:
             conn.autocommit = (
                 True  # Required for REFRESH MATERIALIZED VIEW CONCURRENTLY
@@ -662,274 +515,94 @@ class TableSynchronizer:
             with conn.cursor() as cursor:
                 refresh_materialized_views(cursor, table_name, concurrently=True)
 
-    def _sync_copy_nonblocking(self, table_name: str, plan: Dict[str, Any]):
-        """
-        Mode 2: COPY_NONBLOCKING (Shadow Table Strategy)
-        - Create _upd table (copy).
-        - Drop indexes on _upd.
-        - Ingest data into _upd.
-        - Recreate indexes/MVs on _upd.
-        - Update sync_state updates are collected and applied during swap.
-        - Atomic SWAP.
-        """
-        upd_table = f"{table_name}_upd"
-        bq_schema = self._get_bq_schema(table_name)
-        datasets = sorted(plan["to_update"] + plan["to_insert"])
-
-        sync_state_updates = []  # List of (ds_id, timestamp) to apply at the end
-
-        # Connection for preparation (autocommit to avoid long open tx)
-        conn = psycopg2.connect(self.pg_conn_str)
-        conn.autocommit = True
-        try:
-            with conn.cursor() as cursor:
-                ensure_pg_table_exists(cursor, table_name, bq_schema)
-
-                # A. Prepare Shadow Table
-                copy_table_schema(cursor, table_name, upd_table)
-                # Copy data *except* the datasets we are about to update?
-                # The prompt says "delete old rows and add new rows".
-                # Efficient approach: Copy ALL data, then delete specific datasets?
-                # Or Copy filtering out datasets? Filtering in SQL is better.
-                # However, original logic was: Copy everything, then DELETE rows for datasets being updated.
-                # Let's stick to that for simplicity and correctness.
-                logging.info(
-                    f"      - Copying data from {table_name} to {upd_table}..."
-                )
-                cursor.execute(
-                    sql.SQL("INSERT INTO {} SELECT * FROM {}").format(
-                        sql.Identifier(upd_table), sql.Identifier(table_name)
-                    )
-                )
-
-                # B. Drop indexes on _upd (should be empty, but just in case)
-                drop_indexes(cursor, table_name, suffix="_upd")
-
-                # C. Ingest Loop (Non-transactional on shadow table)
-                for ds_id in tqdm(
-                    datasets, desc=f"    Syncing {upd_table}", unit="dataset"
-                ):
-                    self._ingest_dataset_logic(
-                        cursor, upd_table, table_name, ds_id, bq_schema
-                    )
-                    # Collect sync state update
-                    bq_ts = plan["bq_info"][ds_id][0]
-                    sync_state_updates.append((ds_id, bq_ts))
-
-                # D. Recreate Indexes on _upd
-                create_indexes(cursor, table_name, suffix="_upd")
-
-                # E. Create MVs on _upd
-                create_materialized_views(cursor, table_name, suffix="_upd")
-
-        except Exception:
-            # Cleanup on failure
-            with psycopg2.connect(self.pg_conn_str) as clean_conn:
-                clean_conn.autocommit = True
-                with clean_conn.cursor() as clean_cur:
-                    clean_cur.execute(
-                        sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
-                            sql.Identifier(upd_table)
-                        )
-                    )
-            raise
-        finally:
-            conn.close()
-
-        # F. Atomic Swap & Sync State Update
-        with psycopg2.connect(self.pg_conn_str) as swap_conn:
-            try:
-                with swap_conn.cursor() as cursor:
-                    # We need to update sync_state inside this transaction
-                    logging.info("      - Updating sync_state entries...")
-                    for ds_id, bq_ts in sync_state_updates:
-                        update_sync_state(cursor, table_name, ds_id, bq_ts)
-
-                # Perform the swap (logic handles internal transaction management,
-                # but swap_table expects to manage its own transaction block context usually
-                # or be part of one. The `swap_table` function does `with conn:`, which starts a transaction.
-                # So we should pass the connection.
-                swap_table(swap_conn, table_name)
-            except Exception:
-                # If swap fails, clean up
-                with psycopg2.connect(self.pg_conn_str) as clean_conn:
-                    clean_conn.autocommit = True
-                    with clean_conn.cursor() as clean_cur:
-                        clean_cur.execute(
-                            sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
-                                sql.Identifier(upd_table)
-                            )
-                        )
-                raise
-
-    def _sync_direct_blocking(self, table_name: str, plan: Dict[str, Any]):
-        """
-        Mode 3: DIRECT_BLOCKING
-        - Huge single transaction.
-        - Drop indexes.
-        - Delete old -> Ingest new.
-        - Recreate indexes.
-        - Refresh MVs.
-        - Update sync_state.
-        """
-        bq_schema = self._get_bq_schema(table_name)
-        datasets = sorted(plan["to_update"] + plan["to_insert"])
-
-        with psycopg2.connect(self.pg_conn_str) as conn:
-            with conn.cursor() as cursor:
-                ensure_pg_table_exists(cursor, table_name, bq_schema)
-
-                logging.info(f"    Starting blocking transaction for {table_name}...")
-
-                # 1. Drop Indexes
-                drop_indexes(cursor, table_name)
-
-                # 2. Ingest Data
-                for ds_id in tqdm(
-                    datasets, desc=f"    Syncing {table_name}", unit="dataset"
-                ):
-                    self._ingest_dataset_logic(
-                        cursor, table_name, table_name, ds_id, bq_schema
-                    )
-
-                    # Update sync state
-                    bq_ts = plan["bq_info"][ds_id][0]
-                    update_sync_state(cursor, table_name, ds_id, bq_ts)
-
-                # 3. Recreate Indexes
-                create_indexes(cursor, table_name)
-
-                # 4. Refresh Materialized Views (Standard sync refresh inside transaction)
-                if table_name in MATERIALIZED_VIEW_DEFINITIONS:
-                    for view_name, _, _ in MATERIALIZED_VIEW_DEFINITIONS[table_name]:
-                        logging.info(
-                            f"      - Refreshing materialized view {view_name} (blocking)..."
-                        )
-                        cursor.execute(
-                            sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
-                                sql.Identifier(view_name)
-                            )
-                        )
-
 
 # ------------------------------------------------------------------------------
-# Main
+# Main Execution
 # ------------------------------------------------------------------------------
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--bq-dataset", required=True)
-    parser.add_argument("--bq-location", required=True)
-    parser.add_argument("--pg-conn", required=True)
-    parser.add_argument("--gcs-bucket", required=True)
+    parser = argparse.ArgumentParser(description="BigQuery to PostgreSQL Sync Script")
+    parser.add_argument("--bq-dataset", required=True, help="BigQuery dataset name")
+    parser.add_argument("--bq-location", required=True, help="BigQuery location")
+    parser.add_argument("--pg-conn", required=True, help="PostgreSQL connection string")
     parser.add_argument(
-        "--ingestion-mode",
-        type=IngestionMode,
-        choices=list(IngestionMode),
-        default=IngestionMode.COPY_NONBLOCKING,
-        help="Choose operation mode: live_nonblocking (slow, no copy, no index drop), copy_nonblocking (default, copy table, atomic swap), direct_blocking (fastest, blocks table, drops indexes).",
+        "--gcs-bucket", required=True, help="GCS bucket for temporary files"
     )
     parser.add_argument(
-        "--yes", action="store_true", help="Proceed without confirmation"
+        "--drop-and-recreate-indexes",
+        action="store_true",
+        help="Drop indexes before ingestion and recreate them afterwards (in the same transaction).",
     )
+
     args = parser.parse_args()
 
-    mode = args.ingestion_mode
-    # Since argparse with type=Enum returns the Enum member, we can use it directly.
-    # However, depending on python version it might be different. Let's ensure compatibility.
-    # If type=IngestionMode is used, args.ingestion_mode will be an IngestionMode member.
-
-    logging.info(f"Starting sync in mode: {mode}")
-
-    bq_client = bigquery.Client()
+    # Initialize synchronizer
     synchronizer = TableSynchronizer(
-        mode, args.pg_conn, args.bq_dataset, args.bq_location, args.gcs_bucket
+        drop_and_recreate_indexes=args.drop_and_recreate_indexes,
+        pg_conn_str=args.pg_conn,
+        bq_dataset=args.bq_dataset,
+        bq_location=args.bq_location,
+        gcs_bucket=args.gcs_bucket,
     )
 
+    # Database connection for planning
+    conn = psycopg2.connect(args.pg_conn)
+    conn.autocommit = True
+
     try:
-        # Phase 1: Planning
-        with psycopg2.connect(args.pg_conn) as plan_conn:
-            with plan_conn.cursor() as cursor:
-                logging.info("Fetching current sync states from Postgres...")
-                all_states = get_all_sync_states(cursor)
+        with conn.cursor() as cursor:
+            # fetch current state
+            pg_states = get_all_sync_states(cursor)
+            bq_client = bigquery.Client()
 
-                sync_plan = {}
-                total_datasets = 0
+            for table_name in TABLES_TO_SYNC:
+                logging.info(f"Checking {table_name}...")
 
-                for table_name in TABLES_TO_SYNC:
-                    logging.info(f"Checking BQ table {table_name}...")
+                # 1. Get BQ state
+                try:
                     bq_info = get_bq_latest_timestamps_and_counts(
                         bq_client, args.bq_dataset, table_name, args.bq_location
                     )
-                    current_table_states = all_states.get(table_name, {})
+                except Exception as e:
+                    logging.warning(
+                        f"Could not fetch BQ info for {table_name}: {e}. Skipping."
+                    )
+                    continue
 
-                    to_update = []
-                    to_insert = []
+                # 2. Compare with PG state
+                pg_info = pg_states.get(table_name, {})
+                to_insert = []
+                to_update = []
 
-                    for ds_id, (bq_ts, row_count) in bq_info.items():
-                        if ds_id in current_table_states:
-                            pg_ts = current_table_states[ds_id]
-                            # Simple timezone-aware comparison
-                            if pg_ts is None or bq_ts > pg_ts.replace(
-                                tzinfo=bq_ts.tzinfo
-                            ):
-                                to_update.append(ds_id)
-                        else:
-                            to_insert.append(ds_id)
+                for ds_id, (bq_ts, bq_count) in bq_info.items():
+                    if ds_id not in pg_info:
+                        to_insert.append(ds_id)
+                    else:
+                        pg_ts = pg_info[ds_id]
+                        if bq_ts > pg_ts:
+                            to_update.append(ds_id)
 
-                    if to_update or to_insert:
-                        sync_plan[table_name] = {
-                            "to_update": to_update,
-                            "to_insert": to_insert,
-                            "bq_info": bq_info,
-                        }
-                        total_datasets += len(to_update) + len(to_insert)
+                if not to_insert and not to_update:
+                    logging.info(f"  {table_name} is up to date.")
+                    continue
 
-        # Summary and Confirmation
-        if not sync_plan:
-            logging.info("Everything is up to date. Nothing to sync.")
-            return
+                # 3. Create plan
+                plan = {
+                    "to_insert": to_insert,
+                    "to_update": to_update,
+                    "bq_info": bq_info,
+                }
 
-        print("\n--- Sync Summary ---")
-        for table_name, plan in sync_plan.items():
-            print(f"Table: {table_name}")
-            if plan["to_update"]:
-                print(f"  Datasets to update: {len(plan['to_update'])}")
-                print(
-                    f"    {', '.join(plan['to_update'][:5])}{'...' if len(plan['to_update']) > 5 else ''}"
-                )
-            if plan["to_insert"]:
-                print(f"  Datasets to insert: {len(plan['to_insert'])}")
-                print(
-                    f"    {', '.join(plan['to_insert'][:5])}{'...' if len(plan['to_insert']) > 5 else ''}"
-                )
+                logging.info(f"  Plan for {table_name}:")
+                logging.info(f"    To Insert: {len(to_insert)}")
+                logging.info(f"    To Update: {len(to_update)}")
 
-        print(f"\nTotal datasets to process: {total_datasets}")
-        print(f"Ingestion Mode: {mode}")
-        print("--------------------\n")
+                # 4. Execute Sync
+                synchronizer.sync_table(table_name, plan)
 
-        if not args.yes:
-            try:
-                confirm = input("Proceed with sync? (y/N): ")
-            except EOFError:
-                confirm = "n"
-            if confirm.lower() != "y":
-                logging.info("Sync cancelled by user.")
-                sys.exit(0)
-
-        # Phase 2: Execution
-        for table_name, plan in sync_plan.items():
-            synchronizer.sync_table(table_name, plan)
-
-        logging.info("All sync operations completed.")
-
-    except psycopg2.Error as e:
-        logging.error(f"Postgres connection error: {e}")
-        sys.exit(1)
-    except KeyboardInterrupt:
-        logging.info("\nExiting...")
-        sys.exit(0)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -28,54 +28,111 @@ INDEX_DEFINITIONS = {
     "perturb_seq_dea": [
         (
             "idx_perturbation_dea",
-            "CREATE INDEX idx_perturbation_dea ON public.perturb_seq_dea (perturbed_target_symbol, dataset_id, padj, score_value, log2foldchange)",
+            "CREATE INDEX {idx} ON {table} (perturbed_target_symbol, dataset_id, padj, score_value, log2foldchange)",
         ),
         (
             "idx_phenotype_dea",
-            "CREATE INDEX idx_phenotype_dea ON public.perturb_seq_dea (gene, dataset_id, padj, score_value, log2foldchange)",
+            "CREATE INDEX {idx} ON {table} (gene, dataset_id, padj, score_value, log2foldchange)",
         ),
         (
             "idx_perturbation_phenotype_dea",
-            "CREATE INDEX idx_perturbation_phenotype_dea ON public.perturb_seq_dea (perturbed_target_symbol, gene, dataset_id, padj, score_value, log2foldchange)",
+            "CREATE INDEX {idx} ON {table} (perturbed_target_symbol, gene, dataset_id, padj, score_value, log2foldchange)",
         ),
         (
             "idx_perturb_seq_dea_dataset_id_padj",
-            "CREATE INDEX idx_perturb_seq_dea_dataset_id_padj ON public.perturb_seq_dea (dataset_id, padj) WHERE gene IS NOT NULL",
+            "CREATE INDEX {idx} ON {table} (dataset_id, padj) WHERE gene IS NOT NULL",
         ),
     ],
     "perturb_seq_gsea": [
         (
             "idx_perturbation_gsea",
-            "CREATE INDEX idx_perturbation_gsea ON public.perturb_seq_gsea (perturbed_target_symbol, dataset_id, fdr, nes)",
+            "CREATE INDEX {idx} ON {table} (perturbed_target_symbol, dataset_id, fdr, nes)",
         ),
     ],
     "crispr_data": [
         (
             "idx_crispr_data_dataset",
-            "CREATE INDEX idx_crispr_data_dataset ON public.crispr_data (dataset_id)",
+            "CREATE INDEX {idx} ON {table} (dataset_id)",
         ),
         (
             "idx_crispr_data_target",
-            "CREATE INDEX idx_crispr_data_target ON public.crispr_data (perturbed_target_symbol)",
+            "CREATE INDEX {idx} ON {table} (perturbed_target_symbol)",
         ),
     ],
     "mave_data": [
         (
             "idx_mave_data_dataset",
-            "CREATE INDEX idx_mave_data_dataset ON public.mave_data (dataset_id)",
+            "CREATE INDEX {idx} ON {table} (dataset_id)",
         ),
         (
             "idx_mave_data_target",
-            "CREATE INDEX idx_mave_data_target ON public.mave_data (perturbed_target_symbol, dataset_id)",
+            "CREATE INDEX {idx} ON {table} (perturbed_target_symbol, dataset_id)",
         ),
     ],
 }
 
-PERTURB_SEQ_DEA_MVIEWS = [
-    "perturb_seq_summary_perturbation",
-    "perturb_seq_summary_effect",
-    "perturb_seq_summary_dataset",
-]
+# Materialized view definitions, keyed by base table name.
+# Each entry is (view_name, create_sql_template, [(index_name, index_sql_template), ...]).
+# Templates use {view} for the view name and {source_table} for the base table.
+MATERIALIZED_VIEW_DEFINITIONS = {
+    "perturb_seq_dea": [
+        (
+            "perturb_seq_summary_perturbation",
+            """CREATE MATERIALIZED VIEW {view} AS
+SELECT
+    dataset_id,
+    perturbed_target_symbol,
+    COUNT(*) AS n_total,
+    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
+    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up
+FROM {source_table}
+WHERE padj <= 0.05
+GROUP BY dataset_id, perturbed_target_symbol""",
+            [
+                (
+                    "idx_perturb_seq_summary_perturbation_pk",
+                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id, perturbed_target_symbol)",
+                ),
+            ],
+        ),
+        (
+            "perturb_seq_summary_effect",
+            """CREATE MATERIALIZED VIEW {view} AS
+SELECT
+    dataset_id,
+    gene,
+    COUNT(*) AS n_total,
+    COUNT(*) FILTER (WHERE log2foldchange < 0) AS n_down,
+    COUNT(*) FILTER (WHERE log2foldchange > 0) AS n_up,
+    AVG(score_value) AS avg_score
+FROM {source_table}
+WHERE padj <= 0.05
+GROUP BY dataset_id, gene""",
+            [
+                (
+                    "idx_perturb_seq_summary_effect_pk",
+                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id, gene)",
+                ),
+            ],
+        ),
+        (
+            "perturb_seq_summary_dataset",
+            """CREATE MATERIALIZED VIEW {view} AS
+SELECT
+    dataset_id,
+    COUNT(*) AS n_total
+FROM {source_table}
+WHERE gene IS NOT NULL
+GROUP BY dataset_id""",
+            [
+                (
+                    "idx_perturb_seq_summary_dataset_pk",
+                    "CREATE UNIQUE INDEX {idx} ON {view} (dataset_id)",
+                ),
+            ],
+        ),
+    ],
+}
 
 
 def get_pg_type(field):
@@ -238,9 +295,7 @@ def _download_and_convert_blob(blob, bq_schema):
     return _prepare_table_for_copy(table, bq_schema)
 
 
-def load_parquet_from_gcs_to_pg(
-    cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema, debug_limit=None
-):
+def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
     """Loads Parquet files from GCS into Postgres using COPY.
 
     Uses concurrent GCS downloads and PyArrow's native C++ CSV writer for
@@ -254,12 +309,6 @@ def load_parquet_from_gcs_to_pg(
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
-
-    if debug_limit:
-        logging.info(
-            f"        Debug limit set: reducing shards from {len(blobs)} to {debug_limit}"
-        )
-        blobs = blobs[:debug_limit]
 
     copy_sql = sql.SQL(
         "COPY {} FROM STDIN WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\"', NULL '')"
@@ -351,40 +400,150 @@ def ensure_pg_table_exists(cursor, pg_table, bq_schema):
         )
 
 
-def drop_indexes(cursor, table_name):
+def copy_table(cursor, src_table, dst_table):
+    """Creates a copy of a table with all its data.
+
+    The new table has the same column definitions but no indexes or constraints.
+    """
+    logging.info(f"      - Copying {src_table} -> {dst_table}...")
+    cursor.execute(
+        sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(sql.Identifier(dst_table))
+    )
+    cursor.execute(
+        sql.SQL("CREATE TABLE {} (LIKE {})").format(
+            sql.Identifier(dst_table), sql.Identifier(src_table)
+        )
+    )
+    cursor.execute(
+        sql.SQL("INSERT INTO {} SELECT * FROM {}").format(
+            sql.Identifier(dst_table), sql.Identifier(src_table)
+        )
+    )
+
+
+def drop_indexes(cursor, table_name, suffix=""):
     """Drops all indexes for a given table based on INDEX_DEFINITIONS."""
     if table_name not in INDEX_DEFINITIONS:
         return
-    logging.info(f"      - Dropping indexes for {table_name}...")
+    logging.info(f"      - Dropping indexes for {table_name}{suffix}...")
     for index_name, _ in INDEX_DEFINITIONS[table_name]:
-        logging.info(f"        Dropping {index_name}...")
-        cursor.execute(
-            sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(index_name))
-        )
+        idx = f"{index_name}{suffix}"
+        logging.info(f"        Dropping {idx}...")
+        cursor.execute(sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(idx)))
 
 
-def create_indexes(cursor, table_name):
-    """Creates all indexes for a given table based on INDEX_DEFINITIONS."""
+def create_indexes(cursor, table_name, suffix=""):
+    """Creates all indexes for a given table based on INDEX_DEFINITIONS.
+
+    When suffix is provided, creates indexes with the suffix in both the index
+    name and the target table name.
+    """
     if table_name not in INDEX_DEFINITIONS:
         return
     logging.info(
-        f"      - Reinstating indexes for {table_name} (this may take a while)..."
+        f"      - Creating indexes for {table_name}{suffix} (this may take a while)..."
     )
-    for index_name, index_sql in INDEX_DEFINITIONS[table_name]:
-        logging.info(f"        Creating {index_name}...")
+    for index_name, index_sql_template in INDEX_DEFINITIONS[table_name]:
+        idx = f"{index_name}{suffix}"
+        logging.info(f"        Creating {idx}...")
+        index_sql = index_sql_template.format(
+            idx=sql.Identifier(idx).as_string(cursor.connection),
+            table=sql.Identifier(f"{table_name}{suffix}").as_string(cursor.connection),
+        )
         cursor.execute(index_sql)
 
 
-def refresh_materialized_views(cursor, table_name):
-    """Refreshes materialized views dependent on the table."""
-    if table_name == "perturb_seq_dea":
-        for view_name in PERTURB_SEQ_DEA_MVIEWS:
-            logging.info(f"      - Refreshing materialized view {view_name}...")
+def create_materialized_views(cursor, table_name, suffix=""):
+    """Creates materialized views (with optional suffix) from definitions.
+
+    Views are created against {table_name}{suffix} and named {view_name}{suffix}.
+    """
+    if table_name not in MATERIALIZED_VIEW_DEFINITIONS:
+        return
+    for view_name, create_sql_template, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
+        table_name
+    ]:
+        view = f"{view_name}{suffix}"
+        source = f"{table_name}{suffix}"
+        logging.info(f"      - Creating materialized view {view}...")
+        # Drop if exists (e.g. from a previous failed run)
+        cursor.execute(
+            sql.SQL("DROP MATERIALIZED VIEW IF EXISTS {}").format(sql.Identifier(view))
+        )
+        create_sql = create_sql_template.format(
+            view=sql.Identifier(view).as_string(cursor.connection),
+            source_table=sql.Identifier(source).as_string(cursor.connection),
+        )
+        cursor.execute(create_sql)
+        # Create indexes on the materialized view
+        for mv_index_name, mv_index_sql_template in view_indexes:
+            idx = f"{mv_index_name}{suffix}"
+            logging.info(f"        Creating index {idx}...")
+            mv_index_sql = mv_index_sql_template.format(
+                idx=sql.Identifier(idx).as_string(cursor.connection),
+                view=sql.Identifier(view).as_string(cursor.connection),
+            )
+            cursor.execute(mv_index_sql)
+
+
+def swap_table(conn, table_name):
+    """Atomically swaps {table_name}_upd into {table_name} in a single short transaction.
+
+    Steps (all inside one transaction):
+    1. DROP the original table CASCADE (also drops its materialized views)
+    2. RENAME the _upd table to the original name
+    3. RENAME each _upd materialized view to the original name
+    4. RENAME each _upd index to the original name
+    """
+    upd = f"{table_name}_upd"
+    logging.info(f"      - Swapping {upd} -> {table_name} (short transaction)...")
+
+    with conn:
+        with conn.cursor() as cursor:
+            # 1. Drop original table (CASCADE drops dependent materialized views)
             cursor.execute(
-                sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
-                    sql.Identifier(view_name)
+                sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
+                    sql.Identifier(table_name)
                 )
             )
+
+            # 2. Rename _upd table to original
+            cursor.execute(
+                sql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                    sql.Identifier(upd), sql.Identifier(table_name)
+                )
+            )
+
+            # 3. Rename indexes on the table
+            if table_name in INDEX_DEFINITIONS:
+                for index_name, _ in INDEX_DEFINITIONS[table_name]:
+                    cursor.execute(
+                        sql.SQL("ALTER INDEX {} RENAME TO {}").format(
+                            sql.Identifier(f"{index_name}_upd"),
+                            sql.Identifier(index_name),
+                        )
+                    )
+
+            # 4. Rename materialized views and their indexes
+            if table_name in MATERIALIZED_VIEW_DEFINITIONS:
+                for view_name, _, view_indexes in MATERIALIZED_VIEW_DEFINITIONS[
+                    table_name
+                ]:
+                    cursor.execute(
+                        sql.SQL("ALTER MATERIALIZED VIEW {} RENAME TO {}").format(
+                            sql.Identifier(f"{view_name}_upd"),
+                            sql.Identifier(view_name),
+                        )
+                    )
+                    for mv_index_name, _ in view_indexes:
+                        cursor.execute(
+                            sql.SQL("ALTER INDEX {} RENAME TO {}").format(
+                                sql.Identifier(f"{mv_index_name}_upd"),
+                                sql.Identifier(mv_index_name),
+                            )
+                        )
+
+    logging.info(f"      - Swap complete for {table_name}.")
 
 
 def main():
@@ -395,16 +554,6 @@ def main():
     parser.add_argument("--gcs-bucket", required=True)
     parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
-    )
-    parser.add_argument(
-        "--drop-and-recreate-indexes",
-        action="store_true",
-        help="Drop indexes before loading and recreate them after (faster for bulk loads)",
-    )
-    parser.add_argument(
-        "--debug-limit-N-shards",
-        type=int,
-        help="Only load the first N shards for every dataset (debugging)",
     )
     args = parser.parse_args()
 
@@ -481,106 +630,114 @@ def main():
                 logging.info("Sync cancelled by user.")
                 sys.exit(0)
 
-        # 4. Execution (Per-table connection and transaction)
+        # 4. Execution (Per-table: non-transactional work on _upd copy, then atomic swap)
         overall_pbar = tqdm(
             total=total_datasets, desc="Overall Progress", unit="dataset"
         )
 
         for table_name, plan in sync_plan.items():
             logging.info(f"Syncing table {table_name}...")
+            upd_table = f"{table_name}_upd"
 
             try:
-                # Open a NEW connection for this table
+                # Phase A: Non-transactional work on the _upd copy.
+                # We use autocommit so each statement commits immediately.
+                # This avoids holding a long transaction lock on the original table.
                 conn = psycopg2.connect(args.pg_conn)
+                conn.autocommit = True
                 try:
-                    # Open a transaction block. If this block raises, it rolls back.
-                    # If it exits successfully, it commits.
-                    with conn:
-                        with conn.cursor() as cursor:
-                            bq_table_obj = bq_client.get_table(
-                                f"{args.bq_dataset}.{table_name}"
-                            )
-                            ensure_pg_table_exists(
-                                cursor, table_name, bq_table_obj.schema
-                            )
+                    with conn.cursor() as cursor:
+                        bq_table_obj = bq_client.get_table(
+                            f"{args.bq_dataset}.{table_name}"
+                        )
+                        ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
 
-                            # Drop indexes before bulk update (if requested)
-                            if args.drop_and_recreate_indexes:
-                                drop_indexes(cursor, table_name)
+                        # A1. Copy original table -> _upd table
+                        copy_table(cursor, table_name, upd_table)
 
-                            all_to_process = sorted(
-                                plan["to_update"] + plan["to_insert"]
-                            )
+                        # A2. Drop indexes on _upd table (they were not copied, but
+                        #     drop just in case from a previous partial run)
+                        drop_indexes(cursor, table_name, suffix="_upd")
 
-                            for ds_id in all_to_process:
-                                row_count = plan["bq_info"][ds_id][1]
-                                bq_timestamp = plan["bq_info"][ds_id][0]
+                        # A3. For each dataset: delete old rows, load new data
+                        all_to_process = sorted(plan["to_update"] + plan["to_insert"])
 
-                                # Delete if update
-                                if ds_id in plan["to_update"]:
-                                    delete_dataset_from_pg(cursor, table_name, ds_id)
+                        for ds_id in all_to_process:
+                            bq_timestamp = plan["bq_info"][ds_id][0]
 
-                                # Parquet-based sync via GCS
-                                gcs_prefix = (
-                                    f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
+                            # Delete old data if this is an update
+                            if ds_id in plan["to_update"]:
+                                delete_dataset_from_pg(cursor, upd_table, ds_id)
+
+                            # Export from BQ and load into _upd table
+                            gcs_prefix = f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
+                            logging.info(f"    Processing {ds_id}:")
+
+                            try:
+                                logging.info(
+                                    f"      - Exporting from BigQuery to GCS..."
                                 )
-                                logging.info(f"    Processing {ds_id}:")
-
-                                try:
-                                    logging.info(
-                                        f"      - Exporting from BigQuery to GCS..."
-                                    )
-                                    export_dataset_to_gcs(
-                                        bq_client,
-                                        args.bq_dataset,
-                                        table_name,
-                                        args.bq_location,
-                                        args.gcs_bucket,
-                                        gcs_prefix,
-                                        ds_id,
-                                    )
-
-                                    logging.info(
-                                        f"      - Loading from GCS to Postgres..."
-                                    )
-                                    load_parquet_from_gcs_to_pg(
-                                        cursor,
-                                        table_name,
-                                        args.gcs_bucket,
-                                        gcs_prefix,
-                                        bq_table_obj.schema,
-                                        debug_limit=args.debug_limit_N_shards,
-                                    )
-                                finally:
-                                    cleanup_gcs(args.gcs_bucket, gcs_prefix)
-
-                                # Update sync states
-                                update_sync_state(
-                                    cursor, table_name, ds_id, bq_timestamp
+                                export_dataset_to_gcs(
+                                    bq_client,
+                                    args.bq_dataset,
+                                    table_name,
+                                    args.bq_location,
+                                    args.gcs_bucket,
+                                    gcs_prefix,
+                                    ds_id,
                                 )
 
-                                overall_pbar.update(1)
+                                logging.info(f"      - Loading from GCS to Postgres...")
+                                load_parquet_from_gcs_to_pg(
+                                    cursor,
+                                    upd_table,
+                                    args.gcs_bucket,
+                                    gcs_prefix,
+                                    bq_table_obj.schema,
+                                )
+                            finally:
+                                cleanup_gcs(args.gcs_bucket, gcs_prefix)
 
-                            # Rebuild indexes after all data for this table is loaded
-                            if args.drop_and_recreate_indexes:
-                                create_indexes(cursor, table_name)
+                            # Update sync state (uses the original table name as key)
+                            update_sync_state(cursor, table_name, ds_id, bq_timestamp)
 
-                            # Refresh materialized views dependent on this table
-                            refresh_materialized_views(cursor, table_name)
+                            overall_pbar.update(1)
 
-                    # Transaction commits here automatically for this table.
-                    logging.info(f"Successfully synced {table_name}.")
+                        # A4. Recreate indexes on _upd table
+                        create_indexes(cursor, table_name, suffix="_upd")
+
+                        # A5. Create materialized views from _upd table
+                        create_materialized_views(cursor, table_name, suffix="_upd")
 
                 finally:
                     conn.close()
 
+                # Phase B: Atomic swap (short transaction).
+                conn = psycopg2.connect(args.pg_conn)
+                try:
+                    swap_table(conn, table_name)
+                finally:
+                    conn.close()
+
+                logging.info(f"Successfully synced {table_name}.")
+
             except Exception as e:
-                # This catches errors for THIS table's transaction.
-                # The 'with conn:' block already rolled back the DB transaction.
-                # We log the error and continue to the next table.
                 if isinstance(e, KeyboardInterrupt):
                     raise e  # Allow Ctrl+C to stop everything
                 logging.error(f"Error syncing {table_name}: {e}. Skipping this table.")
+                # Clean up _upd table if it exists
+                try:
+                    cleanup_conn = psycopg2.connect(args.pg_conn)
+                    cleanup_conn.autocommit = True
+                    with cleanup_conn.cursor() as cleanup_cursor:
+                        cleanup_cursor.execute(
+                            sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
+                                sql.Identifier(upd_table)
+                            )
+                        )
+                    cleanup_conn.close()
+                except Exception:
+                    pass
 
         overall_pbar.close()
         logging.info("Multi-table sync operations completed.")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import io
 import sys
+import uuid
 
 from google.cloud import bigquery
 import psycopg2
@@ -90,7 +91,6 @@ def get_pg_type(field):
 
 def get_all_sync_states(cursor):
     """Gets the current sync state for all tables and datasets from Postgres."""
-    states = {}
     cursor.execute(
         """
         CREATE TABLE IF NOT EXISTS sync_state (
@@ -101,6 +101,13 @@ def get_all_sync_states(cursor):
         );
     """
     )
+    cursor.execute("SELECT table_name, dataset_id, last_synced_at FROM sync_state")
+    for table_name, dataset_id, last_synced_at in cursor.fetchall():
+        if table_name not in states:  # Bug here in previous version, fixing.
+            pass  # Actually 'states' is local here.
+
+    # Corrected implementation:
+    states = {}
     cursor.execute("SELECT table_name, dataset_id, last_synced_at FROM sync_state")
     for table_name, dataset_id, last_synced_at in cursor.fetchall():
         if table_name not in states:
@@ -121,13 +128,37 @@ def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_loca
     return {row.dataset_id: (row.latest_ts, row.row_count) for row in results}
 
 
-def stream_bq_to_pg(cursor, pg_table, bq_client, bq_query, bq_schema, total_rows):
-    """Streams data from a BQ query directly into a Postgres table using COPY."""
-    query_job = bq_client.query(bq_query)
-    row_iterator = query_job.result()
+def stream_bq_to_pg(
+    cursor,
+    pg_table,
+    bq_client,
+    bq_dataset,
+    bq_table,
+    bq_location,
+    dataset_id,
+    bq_schema,
+    total_rows,
+):
+    """Streams data from a large BQ query directly into a Postgres table using a temp destination table."""
+    # Use a destination table for the query result if it's potentially huge.
+    # To keep things robust, we'll ALWAYS use a destination table for dataset ingestion.
+    temp_table_id = f"{bq_client.project}.{bq_dataset}.temp_sync_{uuid.uuid4().hex}"
+
+    job_config = bigquery.QueryJobConfig(
+        destination=temp_table_id,
+        write_disposition="WRITE_TRUNCATE",
+    )
+
+    query = f"SELECT * FROM `{bq_dataset}.{bq_table}` WHERE dataset_id = '{dataset_id}'"
+
+    query_job = bq_client.query(query, job_config=job_config, location=bq_location)
+    query_job.result()  # Wait for completion
+
+    # Fetch rows from the destination table. This avoids result size limits.
+    row_iterator = bq_client.list_rows(temp_table_id)
 
     with tqdm(
-        total=total_rows, desc=f"    Loading rows to {pg_table}", leave=False
+        total=total_rows, desc=f"    Loading {dataset_id}", leave=False, unit="rows"
     ) as pbar:
         stream = BQRowIteratorIO(row_iterator, bq_schema, pbar=pbar)
         cursor.copy_expert(
@@ -136,6 +167,9 @@ def stream_bq_to_pg(cursor, pg_table, bq_client, bq_query, bq_schema, total_rows
             ),
             stream,
         )
+
+    # Clean up temp table
+    bq_client.delete_table(temp_table_id, not_found_ok=True)
 
 
 def delete_dataset_from_pg(cursor, pg_table, dataset_id):
@@ -199,8 +233,7 @@ def main():
 
                 # 2. Plan sync for each table
                 sync_plan = {}
-                total_to_update = 0
-                total_to_insert = 0
+                total_datasets = 0
 
                 for table_name in TABLES_TO_SYNC:
                     logging.info(f"Checking BQ table {table_name}...")
@@ -228,8 +261,7 @@ def main():
                             "to_insert": to_insert,
                             "bq_info": bq_info,
                         }
-                        total_to_update += len(to_update)
-                        total_to_insert += len(to_insert)
+                        total_datasets += len(to_update) + len(to_insert)
 
                 # 3. Summary and confirmation
                 if not sync_plan:
@@ -250,9 +282,7 @@ def main():
                             f"    {', '.join(plan['to_insert'][:5])}{'...' if len(plan['to_insert']) > 5 else ''}"
                         )
 
-                print(
-                    f"\nTotal datasets to process: {total_to_update + total_to_insert}"
-                )
+                print(f"\nTotal datasets to process: {total_datasets}")
                 print("--------------------\n")
 
                 if not args.yes:
@@ -264,7 +294,11 @@ def main():
                         logging.info("Sync cancelled by user.")
                         sys.exit(0)
 
-                # 4. Sequential Execution
+                # 4. Sequential Execution (one dataset at a time)
+                overall_pbar = tqdm(
+                    total=total_datasets, desc="Overall Progress", unit="dataset"
+                )
+
                 for table_name, plan in sync_plan.items():
                     logging.info(f"Syncing table {table_name}...")
 
@@ -274,63 +308,50 @@ def main():
                     ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
 
                     all_to_process = sorted(plan["to_update"] + plan["to_insert"])
-                    chunk_size = 5
 
-                    overall_pbar = tqdm(
-                        total=len(all_to_process),
-                        desc=f"  Table {table_name}",
-                        leave=True,
-                    )
-
-                    for i in range(0, len(all_to_process), chunk_size):
-                        chunk = all_to_process[i : i + chunk_size]
-                        chunk_rows = sum([plan["bq_info"][ds_id][1] for ds_id in chunk])
+                    for ds_id in all_to_process:
+                        row_count = plan["bq_info"][ds_id][1]
+                        bq_timestamp = plan["bq_info"][ds_id][0]
 
                         try:
                             # Delete if update
-                            for ds_id in chunk:
-                                if ds_id in plan["to_update"]:
-                                    delete_dataset_from_pg(cursor, table_name, ds_id)
+                            if ds_id in plan["to_update"]:
+                                delete_dataset_from_pg(cursor, table_name, ds_id)
 
-                            # Build query for the chunk
-                            ds_ids_str = ", ".join([f"'{ds}'" for ds in chunk])
-                            bq_query = f"SELECT * FROM `{args.bq_dataset}.{table_name}` WHERE dataset_id IN ({ds_ids_str})"
-
-                            # Stream directly from BQ to PG
+                            # Stream directly from BQ to PG using a temp destination table for safety
                             stream_bq_to_pg(
                                 cursor,
                                 table_name,
                                 bq_client,
-                                bq_query,
+                                args.bq_dataset,
+                                table_name,
+                                args.bq_location,
+                                ds_id,
                                 bq_table_obj.schema,
-                                chunk_rows,
+                                row_count,
                             )
 
                             # Update sync states
-                            for ds_id in chunk:
-                                update_sync_state(
-                                    cursor, table_name, ds_id, plan["bq_info"][ds_id][0]
-                                )
+                            update_sync_state(cursor, table_name, ds_id, bq_timestamp)
 
-                            # COMMIT EACH CHUNK
+                            # COMMIT EVERY DATASET
                             conn.commit()
-                            overall_pbar.update(len(chunk))
+                            overall_pbar.update(1)
 
                         except (Exception, KeyboardInterrupt) as e:
                             conn.rollback()
                             overall_pbar.close()
                             if isinstance(e, KeyboardInterrupt):
                                 logging.error(
-                                    f"\nSync of {table_name} interrupted. Rolling back current chunk..."
+                                    f"\nSync of {table_name}/{ds_id} interrupted. Rolling back..."
                                 )
                             else:
                                 logging.error(
-                                    f"\nError syncing {table_name}: {e}. Rolling back..."
+                                    f"\nError syncing {table_name}/{ds_id}: {e}. Rolling back..."
                                 )
                             sys.exit(1)
 
-                    overall_pbar.close()
-
+                overall_pbar.close()
                 logging.info("Multi-table sync completed successfully.")
 
     except psycopg2.Error as e:

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import uuid
 import io
-import json
+import sys
 
 from google.cloud import bigquery, storage
 import psycopg2
@@ -10,183 +10,7 @@ from psycopg2 import sql
 from tqdm import tqdm
 import pyarrow.parquet as pq
 
-logging.basicConfig(level=logging.INFO)
-
-
-def get_last_synced_at(pg_conn, pg_table):
-    """Gets the last synced timestamp from the sync_state table."""
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS sync_state (
-                    table_name TEXT NOT NULL PRIMARY KEY,
-                    last_synced_at TIMESTAMP WITHOUT TIME ZONE
-                );
-            """
-            )
-            cursor.execute(
-                "SELECT last_synced_at FROM sync_state WHERE table_name = %s",
-                (pg_table,),
-            )
-            result = cursor.fetchone()
-            return result[0] if result else None
-
-
-def export_bq_to_gcs(
-    bq_client,
-    bq_dataset,
-    bq_table,
-    bq_location,
-    gcs_bucket,
-    gcs_file_path_prefix,
-    last_synced_at,
-):
-    """Exports data from BigQuery to a GCS bucket in Parquet format."""
-    dataset_ref = bq_client.dataset(bq_dataset)
-    table_ref = dataset_ref.table(bq_table)
-    destination_uri = f"gs://{gcs_bucket}/{gcs_file_path_prefix}-*.parquet"
-
-    job_config = bigquery.ExtractJobConfig(destination_format="PARQUET")
-
-    if last_synced_at:
-        # Incremental load: query to a temporary table, then export.
-        temp_table_id = f"temp_export_{uuid.uuid4().hex}"
-        temp_table_ref = dataset_ref.table(temp_table_id)
-
-        query = f"""
-        SELECT *
-        FROM `{bq_dataset}.{bq_table}`
-        WHERE max_ingested_at > TIMESTAMP('{last_synced_at.isoformat()}')
-        """
-        query_job_config = bigquery.QueryJobConfig(destination=temp_table_ref)
-
-        query_job = bq_client.query(
-            query, job_config=query_job_config, location=bq_location
-        )
-        query_job.result()  # Wait for the query to finish
-
-        extract_job = bq_client.extract_table(
-            temp_table_ref,
-            destination_uri,
-            location=bq_location,
-            job_config=job_config,
-        )
-        extract_job.result()  # Wait for the extract to finish
-
-        bq_client.delete_table(temp_table_ref)  # Clean up temp table
-
-    else:
-        # Full load: direct export
-        extract_job = bq_client.extract_table(
-            table_ref,
-            destination_uri,
-            location=bq_location,
-            job_config=job_config,
-        )
-        extract_job.result()
-
-    logging.info(f"Exported data to gs://{gcs_bucket}/{gcs_file_path_prefix}-*.parquet")
-
-
-def load_to_postgres(
-    pg_conn,
-    pg_table,
-    gcs_bucket,
-    gcs_file_path_prefix,
-    last_synced_at,
-    bq_client,
-    bq_dataset,
-    bq_table_name,
-    force_full=False,
-):
-    """Loads data from a GCS Parquet file into a PostgreSQL table."""
-    gcs_client = storage.Client()
-    bucket = gcs_client.get_bucket(gcs_bucket)
-    blobs = list(bucket.list_blobs(prefix=gcs_file_path_prefix))
-
-    table = bq_client.get_table(f"{bq_dataset}.{bq_table_name}")
-    schema = table.schema
-
-    def format_row(row, schema):
-        formatted = []
-        for i, field in enumerate(schema):
-            val = row[i]
-            if val is None:
-                formatted.append("")
-            elif field.mode == "REPEATED":
-                # Convert list to Postgres array literal: {"val1", "val2"}
-                # We use json.dumps to handle basic quoting for strings.
-                inner = [str(x) if not isinstance(x, str) else x for x in val]
-                # Simple quoting for postgres array format
-                escaped = []
-                for x in inner:
-                    x_str = str(x).replace('"', '\\"')
-                    escaped.append(f'"{x_str}"')
-                formatted.append(f'{{{",".join(escaped)}}}')
-            elif field.field_type == "BOOLEAN":
-                formatted.append("true" if val else "false")
-            else:
-                formatted.append(str(val))
-        return "\t".join(formatted)
-
-    def stream_parquet_to_pg(cursor, target_table, blobs, schema):
-        for blob in tqdm(blobs, desc=f"Loading shards to {target_table}"):
-            with blob.open("rb") as f:
-                parquet_file = pq.ParquetFile(f)
-                for i in range(parquet_file.num_row_groups):
-                    table = parquet_file.read_row_group(i)
-                    rows = table.to_pylist()
-
-                    # Convert rows to TSV format for COPY
-                    tsv_data = io.StringIO()
-                    for row_dict in rows:
-                        # Convert dict to ordered list based on schema
-                        row_val = [row_dict.get(field.name) for field in schema]
-                        tsv_data.write(format_row(row_val, schema) + "\n")
-
-                    tsv_data.seek(0)
-                    cursor.copy_expert(
-                        sql.SQL(
-                            "COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')"
-                        ).format(sql.Identifier(target_table)),
-                        tsv_data,
-                    )
-
-    with psycopg2.connect(pg_conn) as conn:
-        with conn.cursor() as cursor:
-            # Check if table exists
-            cursor.execute(
-                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
-                (pg_table,),
-            )
-            table_exists = cursor.fetchone()[0]
-
-            if not force_full and last_synced_at and table_exists:
-                # Incremental load: append to existing table
-                stream_parquet_to_pg(cursor, pg_table, blobs, schema)
-            else:
-                # Full load or first load
-                if table_exists:
-                    # preserve indexes by truncating instead of dropping
-                    logging.info(
-                        f"Table {pg_table} exists. Truncating for full reload."
-                    )
-                    cursor.execute(
-                        sql.SQL("TRUNCATE TABLE {}").format(sql.Identifier(pg_table))
-                    )
-                    stream_parquet_to_pg(cursor, pg_table, blobs, schema)
-                else:
-                    # Initial load: create table and load
-                    logging.info(f"Table {pg_table} does not exist. Creating.")
-                    columns = [f"{field.name} {get_pg_type(field)}" for field in schema]
-                    cursor.execute(
-                        sql.SQL("CREATE TABLE {} ({})").format(
-                            sql.Identifier(pg_table),
-                            sql.SQL(", ").join(map(sql.SQL, columns)),
-                        )
-                    )
-                    stream_parquet_to_pg(cursor, pg_table, blobs, schema)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
 def get_pg_type(field):
@@ -207,36 +31,188 @@ def get_pg_type(field):
     return pg_type
 
 
-def update_sync_state(
-    pg_conn, pg_table, bq_client, bq_dataset, bq_table_name, bq_location
-):
-    """Updates the sync_state table with the latest timestamp."""
-    query = f"SELECT MAX(max_ingested_at) FROM `{bq_dataset}.{bq_table_name}`"
-    query_job = bq_client.query(query, location=bq_location)
-    max_ingested_at = list(query_job.result())[0][0]
+def get_all_sync_states(pg_conn):
+    """Gets the current sync state for all tables and datasets."""
+    states = {}
+    with psycopg2.connect(pg_conn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sync_state (
+                    table_name TEXT NOT NULL,
+                    dataset_id TEXT NOT NULL,
+                    last_synced_at TIMESTAMP WITHOUT TIME ZONE,
+                    PRIMARY KEY (table_name, dataset_id)
+                );
+            """
+            )
+            cursor.execute(
+                "SELECT table_name, dataset_id, last_synced_at FROM sync_state"
+            )
+            for table_name, dataset_id, last_synced_at in cursor.fetchall():
+                if table_name not in states:
+                    states[table_name] = {}
+                states[table_name][dataset_id] = last_synced_at
+    return states
 
-    if max_ingested_at:
-        with psycopg2.connect(pg_conn) as conn:
-            with conn.cursor() as cursor:
+
+def get_bq_latest_timestamps(bq_client, bq_dataset, bq_table, bq_location):
+    """Gets the latest max_ingested_at for every dataset_id in a BQ table."""
+    query = f"""
+        SELECT dataset_id, MAX(max_ingested_at) as latest_ts
+        FROM `{bq_dataset}.{bq_table}`
+        GROUP BY dataset_id
+    """
+    query_job = bq_client.query(query, location=bq_location)
+    results = query_job.result()
+    return {row.dataset_id: row.latest_ts for row in results}
+
+
+def export_bq_to_gcs(
+    bq_client,
+    bq_dataset,
+    bq_table,
+    bq_location,
+    gcs_bucket,
+    gcs_file_path_prefix,
+    dataset_ids,
+):
+    """Exports specific datasets from BigQuery to GCS in Parquet format."""
+    dataset_ref = bq_client.dataset(bq_dataset)
+    destination_uri = f"gs://{gcs_bucket}/{gcs_file_path_prefix}-*.parquet"
+
+    job_config = bigquery.ExtractJobConfig(destination_format="PARQUET")
+
+    # Query to a temporary table, then export.
+    temp_table_id = f"temp_export_{uuid.uuid4().hex}"
+    temp_table_ref = dataset_ref.table(temp_table_id)
+
+    # Convert dataset_ids to a SQL-compatible list
+    dataset_ids_str = ", ".join([f"'{ds}'" for ds in dataset_ids])
+    query = f"""
+    SELECT *
+    FROM `{bq_dataset}.{bq_table}`
+    WHERE dataset_id IN ({dataset_ids_str})
+    """
+    query_job_config = bigquery.QueryJobConfig(destination=temp_table_ref)
+
+    query_job = bq_client.query(
+        query, job_config=query_job_config, location=bq_location
+    )
+    query_job.result()  # Wait for the query to finish
+
+    extract_job = bq_client.extract_table(
+        temp_table_ref,
+        destination_uri,
+        location=bq_location,
+        job_config=job_config,
+    )
+    extract_job.result()  # Wait for the extract to finish
+
+    bq_client.delete_table(temp_table_ref)  # Clean up temp table
+    return destination_uri
+
+
+def format_row(row, schema):
+    formatted = []
+    for i, field in enumerate(schema):
+        val = row[i]
+        if val is None:
+            formatted.append("")
+        elif field.mode == "REPEATED":
+            inner = [str(x) if not isinstance(x, str) else x for x in val]
+            escaped = []
+            for x in inner:
+                x_str = str(x).replace('"', '\\"')
+                escaped.append(f'"{x_str}"')
+            formatted.append(f'{{{",".join(escaped)}}}')
+        elif field.field_type == "BOOLEAN":
+            formatted.append("true" if val else "false")
+        else:
+            formatted.append(str(val))
+    return "\t".join(formatted)
+
+
+def load_parquet_to_pg(cursor, pg_table, gcs_bucket, gcs_file_path_prefix, schema):
+    """Loads parquet shards from GCS into Postgres using COPY."""
+    gcs_client = storage.Client()
+    bucket = gcs_client.get_bucket(gcs_bucket)
+    blobs = list(bucket.list_blobs(prefix=gcs_file_path_prefix))
+
+    for blob in tqdm(blobs, desc=f"Loading shards to {pg_table}", leave=False):
+        with blob.open("rb") as f:
+            parquet_file = pq.ParquetFile(f)
+            for i in range(parquet_file.num_row_groups):
+                table = parquet_file.read_row_group(i)
+                rows = table.to_pylist()
+
+                tsv_data = io.StringIO()
+                for row_dict in rows:
+                    row_val = [row_dict.get(field.name) for field in schema]
+                    tsv_data.write(format_row(row_val, schema) + "\n")
+
+                tsv_data.seek(0)
+                cursor.copy_expert(
+                    sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
+                        sql.Identifier(pg_table)
+                    ),
+                    tsv_data,
+                )
+
+
+def update_sync_state(pg_conn, pg_table, dataset_id, timestamp):
+    """Updates or inserts the sync state for a specific dataset."""
+    with psycopg2.connect(pg_conn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO sync_state (table_name, dataset_id, last_synced_at)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (table_name, dataset_id) DO UPDATE
+                SET last_synced_at = EXCLUDED.last_synced_at;
+            """,
+                (pg_table, dataset_id, timestamp),
+            )
+
+
+def delete_dataset_from_pg(pg_conn, pg_table, dataset_id):
+    """Deletes all rows for a given dataset_id from a Postgres table."""
+    with psycopg2.connect(pg_conn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                sql.SQL("DELETE FROM {} WHERE dataset_id = %s").format(
+                    sql.Identifier(pg_table)
+                ),
+                (dataset_id,),
+            )
+
+
+def ensure_pg_table_exists(pg_conn, pg_table, bq_schema):
+    """Ensures the target table exists in Postgres, creating it if necessary."""
+    with psycopg2.connect(pg_conn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
+                (pg_table,),
+            )
+            if not cursor.fetchone()[0]:
+                logging.info(f"Table {pg_table} does not exist. Creating.")
+                columns = [f"{field.name} {get_pg_type(field)}" for field in bq_schema]
                 cursor.execute(
-                    """
-                    INSERT INTO sync_state (table_name, last_synced_at)
-                    VALUES (%s, %s)
-                    ON CONFLICT (table_name) DO UPDATE
-                    SET last_synced_at = EXCLUDED.last_synced_at;
-                """,
-                    (pg_table, max_ingested_at),
+                    sql.SQL("CREATE TABLE {} ({})").format(
+                        sql.Identifier(pg_table),
+                        sql.SQL(", ").join(map(sql.SQL, columns)),
+                    )
                 )
 
 
 def cleanup_gcs(gcs_bucket, gcs_file_path_prefix):
-    """Removes the temporary files from GCS."""
+    """Removes temporary files from GCS."""
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_file_path_prefix))
     for blob in blobs:
         blob.delete()
-    logging.info(f"Deleted files with prefix gs://{gcs_bucket}/{gcs_file_path_prefix}")
 
 
 def main():
@@ -248,46 +224,113 @@ def main():
     parser.add_argument("--pg-table", required=True)
     parser.add_argument("--gcs-bucket", required=True)
     parser.add_argument(
-        "--full", action="store_true", help="Perform a full reload of the table"
+        "--yes", action="store_true", help="Proceed without confirmation"
     )
     args = parser.parse_args()
 
     bq_client = bigquery.Client()
-    gcs_file_path_prefix = f"tmp/{args.bq_dataset}_{args.bq_table}_{uuid.uuid4()}"
 
-    last_synced_at = (
-        get_last_synced_at(args.pg_conn, args.pg_table) if not args.full else None
+    # 1. Fetch current sync states
+    logging.info("Fetching current sync states from Postgres...")
+    all_states = get_all_sync_states(args.pg_conn)
+    current_table_states = all_states.get(args.pg_table, {})
+
+    # 2. Fetch latest timestamps from BQ
+    logging.info(f"Fetching latest dataset timestamps from BQ table {args.bq_table}...")
+    bq_latest = get_bq_latest_timestamps(
+        bq_client, args.bq_dataset, args.bq_table, args.bq_location
     )
 
-    export_bq_to_gcs(
-        bq_client,
-        args.bq_dataset,
-        args.bq_table,
-        args.bq_location,
-        args.gcs_bucket,
-        gcs_file_path_prefix,
-        last_synced_at,
-    )
-    load_to_postgres(
-        args.pg_conn,
-        args.pg_table,
-        args.gcs_bucket,
-        gcs_file_path_prefix,
-        last_synced_at,
-        bq_client,
-        args.bq_dataset,
-        args.bq_table,
-        force_full=args.full,
-    )
-    update_sync_state(
-        args.pg_conn,
-        args.pg_table,
-        bq_client,
-        args.bq_dataset,
-        args.bq_table,
-        args.bq_location,
-    )
-    cleanup_gcs(args.gcs_bucket, gcs_file_path_prefix)
+    # 3. Determine datasets to process
+    to_update = []  # Exists in PG but timestamp in BQ is newer
+    to_insert = []  # Does not exist in PG
+
+    for ds_id, bq_ts in bq_latest.items():
+        if ds_id in current_table_states:
+            pg_ts = current_table_states[ds_id]
+            # BQ timestamp is offset-aware usually, but let's be careful.
+            # Comparison assumes both are comparable.
+            if pg_ts is None or bq_ts > pg_ts.replace(tzinfo=bq_ts.tzinfo):
+                to_update.append(ds_id)
+        else:
+            to_insert.append(ds_id)
+
+    # 4. Summary and confirmation
+    total_to_process = len(to_update) + len(to_insert)
+    if total_to_process == 0:
+        logging.info("Everything is up to date. Nothing to sync.")
+        return
+
+    print("\n--- Sync Summary ---")
+    print(f"Table: {args.pg_table}")
+    print(f"Datasets to update (delete + re-ingest): {len(to_update)}")
+    if to_update:
+        print(f"  {', '.join(to_update[:10])}{'...' if len(to_update) > 10 else ''}")
+    print(f"Datasets to insert (new): {len(to_insert)}")
+    if to_insert:
+        print(f"  {', '.join(to_insert[:10])}{'...' if len(to_insert) > 10 else ''}")
+    print(f"Total datasets to process: {total_to_process}")
+    print("--------------------\n")
+
+    if not args.yes:
+        confirm = input("Proceed with sync? (y/N): ")
+        if confirm.lower() != "y":
+            logging.info("Sync cancelled by user.")
+            sys.exit(0)
+
+    # 5. Execution
+    bq_table_obj = bq_client.get_table(f"{args.bq_dataset}.{args.bq_table}")
+    ensure_pg_table_exists(args.pg_conn, args.pg_table, bq_table_obj.schema)
+
+    all_to_process = sorted(to_update + to_insert)
+    # We process in chunks to avoid massive GCS exports if many datasets
+    chunk_size = 10  # Tuneable
+
+    pbar = tqdm(total=len(all_to_process), desc="Synchronizing datasets")
+
+    for i in range(0, len(all_to_process), chunk_size):
+        chunk = all_to_process[i : i + chunk_size]
+        gcs_prefix = f"tmp/{args.bq_dataset}_{args.bq_table}_{uuid.uuid4()}"
+
+        try:
+            # Delete if update
+            for ds_id in chunk:
+                if ds_id in to_update:
+                    delete_dataset_from_pg(args.pg_conn, args.pg_table, ds_id)
+
+            # Export chunk to GCS
+            export_bq_to_gcs(
+                bq_client,
+                args.bq_dataset,
+                args.bq_table,
+                args.bq_location,
+                args.gcs_bucket,
+                gcs_prefix,
+                chunk,
+            )
+
+            # Load to Postgres
+            with psycopg2.connect(args.pg_conn) as conn:
+                with conn.cursor() as cursor:
+                    load_parquet_to_pg(
+                        cursor,
+                        args.pg_table,
+                        args.gcs_bucket,
+                        gcs_prefix,
+                        bq_table_obj.schema,
+                    )
+
+            # Update sync states
+            for ds_id in chunk:
+                update_sync_state(args.pg_conn, args.pg_table, ds_id, bq_latest[ds_id])
+
+            pbar.update(len(chunk))
+
+        finally:
+            cleanup_gcs(args.gcs_bucket, gcs_prefix)
+
+    pbar.close()
+    logging.info("Sync completed successfully.")
 
 
 if __name__ == "__main__":

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -166,6 +166,8 @@ def export_dataset_to_gcs(
     destination_uri = f"gs://{gcs_bucket}/{gcs_prefix}-*.parquet"
     dataset_ref = bq_client.dataset(bq_dataset)
 
+    logging.info(f"        Exporting {dataset_id} to GCS...")
+
     # Query to a temporary table to filter by dataset_id
     temp_table_id = f"temp_sync_{uuid.uuid4().hex}"
     temp_table_ref = dataset_ref.table(temp_table_id)
@@ -256,6 +258,7 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
     """Loads Parquet files from GCS into Postgres using COPY."""
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
+    logging.info(f"        Listing blobs in {gcs_prefix}...")
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
 
     if not blobs:
@@ -310,6 +313,7 @@ def cleanup_gcs(gcs_bucket, gcs_prefix):
 
 def delete_dataset_from_pg(cursor, pg_table, dataset_id):
     """Deletes all rows for a given dataset_id from a Postgres table."""
+    logging.info(f"        Deleting {dataset_id} from {pg_table}...")
     cursor.execute(
         sql.SQL("DELETE FROM {} WHERE dataset_id = %s").format(
             sql.Identifier(pg_table)
@@ -355,6 +359,7 @@ def drop_indexes(cursor, table_name, suffix=""):
     logging.info(f"      - Dropping indexes for {table_name}{suffix}...")
     for index_name, _ in INDEX_DEFINITIONS[table_name]:
         idx = f"{index_name}{suffix}"
+        logging.info(f"        Dropping {idx}...")
         cursor.execute(sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(idx)))
 
 

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -10,6 +10,13 @@ from tqdm import tqdm
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+TABLES_TO_SYNC = [
+    "crispr_data",
+    "mave_data",
+    "perturb_seq_dea",
+    "perturb_seq_gsea",
+]
+
 
 class BQRowIteratorIO(io.RawIOBase):
     """File-like object that streams rows from a BigQuery iterator in TSV format."""
@@ -120,7 +127,7 @@ def stream_bq_to_pg(cursor, pg_table, bq_client, bq_query, bq_schema, total_rows
     row_iterator = query_job.result()
 
     with tqdm(
-        total=total_rows, desc=f"  Loading rows to {pg_table}", leave=False
+        total=total_rows, desc=f"    Loading rows to {pg_table}", leave=False
     ) as pbar:
         stream = BQRowIteratorIO(row_iterator, bq_schema, pbar=pbar)
         cursor.copy_expert(
@@ -174,10 +181,8 @@ def ensure_pg_table_exists(cursor, pg_table, bq_schema):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bq-dataset", required=True)
-    parser.add_argument("--bq-table", required=True)
     parser.add_argument("--bq-location", required=True)
     parser.add_argument("--pg-conn", required=True)
-    parser.add_argument("--pg-table", required=True)
     parser.add_argument(
         "--yes", action="store_true", help="Proceed without confirmation"
     )
@@ -188,50 +193,66 @@ def main():
     try:
         with psycopg2.connect(args.pg_conn) as conn:
             with conn.cursor() as cursor:
-                # 1. Fetch current sync states
+                # 1. Fetch current sync states for all tables
                 logging.info("Fetching current sync states from Postgres...")
                 all_states = get_all_sync_states(cursor)
-                current_table_states = all_states.get(args.pg_table, {})
 
-                # 2. Fetch latest timestamps and counts from BQ
-                logging.info(
-                    f"Fetching latest dataset info from BQ table {args.bq_table}..."
-                )
-                bq_info = get_bq_latest_timestamps_and_counts(
-                    bq_client, args.bq_dataset, args.bq_table, args.bq_location
-                )
+                # 2. Plan sync for each table
+                sync_plan = {}
+                total_to_update = 0
+                total_to_insert = 0
 
-                # 3. Determine datasets to process
-                to_update = []  # Exists in PG but timestamp in BQ is newer
-                to_insert = []  # Does not exist in PG
+                for table_name in TABLES_TO_SYNC:
+                    logging.info(f"Checking BQ table {table_name}...")
+                    bq_info = get_bq_latest_timestamps_and_counts(
+                        bq_client, args.bq_dataset, table_name, args.bq_location
+                    )
+                    current_table_states = all_states.get(table_name, {})
 
-                for ds_id, (bq_ts, _) in bq_info.items():
-                    if ds_id in current_table_states:
-                        pg_ts = current_table_states[ds_id]
-                        if pg_ts is None or bq_ts > pg_ts.replace(tzinfo=bq_ts.tzinfo):
-                            to_update.append(ds_id)
-                    else:
-                        to_insert.append(ds_id)
+                    to_update = []
+                    to_insert = []
 
-                # 4. Summary and confirmation
-                total_to_process = len(to_update) + len(to_insert)
-                if total_to_process == 0:
+                    for ds_id, (bq_ts, row_count) in bq_info.items():
+                        if ds_id in current_table_states:
+                            pg_ts = current_table_states[ds_id]
+                            if pg_ts is None or bq_ts > pg_ts.replace(
+                                tzinfo=bq_ts.tzinfo
+                            ):
+                                to_update.append(ds_id)
+                        else:
+                            to_insert.append(ds_id)
+
+                    if to_update or to_insert:
+                        sync_plan[table_name] = {
+                            "to_update": to_update,
+                            "to_insert": to_insert,
+                            "bq_info": bq_info,
+                        }
+                        total_to_update += len(to_update)
+                        total_to_insert += len(to_insert)
+
+                # 3. Summary and confirmation
+                if not sync_plan:
                     logging.info("Everything is up to date. Nothing to sync.")
                     return
 
                 print("\n--- Sync Summary ---")
-                print(f"Table: {args.pg_table}")
-                print(f"Datasets to update (delete + re-ingest): {len(to_update)}")
-                if to_update:
-                    print(
-                        f"  {', '.join(to_update[:10])}{'...' if len(to_update) > 10 else ''}"
-                    )
-                print(f"Datasets to insert (new): {len(to_insert)}")
-                if to_insert:
-                    print(
-                        f"  {', '.join(to_insert[:10])}{'...' if len(to_insert) > 10 else ''}"
-                    )
-                print(f"Total datasets to process: {total_to_process}")
+                for table_name, plan in sync_plan.items():
+                    print(f"Table: {table_name}")
+                    if plan["to_update"]:
+                        print(f"  Datasets to update: {len(plan['to_update'])}")
+                        print(
+                            f"    {', '.join(plan['to_update'][:5])}{'...' if len(plan['to_update']) > 5 else ''}"
+                        )
+                    if plan["to_insert"]:
+                        print(f"  Datasets to insert: {len(plan['to_insert'])}")
+                        print(
+                            f"    {', '.join(plan['to_insert'][:5])}{'...' if len(plan['to_insert']) > 5 else ''}"
+                        )
+
+                print(
+                    f"\nTotal datasets to process: {total_to_update + total_to_insert}"
+                )
                 print("--------------------\n")
 
                 if not args.yes:
@@ -243,68 +264,74 @@ def main():
                         logging.info("Sync cancelled by user.")
                         sys.exit(0)
 
-                # 5. Execution
-                bq_table_obj = bq_client.get_table(f"{args.bq_dataset}.{args.bq_table}")
-                ensure_pg_table_exists(cursor, args.pg_table, bq_table_obj.schema)
+                # 4. Sequential Execution
+                for table_name, plan in sync_plan.items():
+                    logging.info(f"Syncing table {table_name}...")
 
-                all_to_process = sorted(to_update + to_insert)
-                chunk_size = 5
+                    bq_table_obj = bq_client.get_table(
+                        f"{args.bq_dataset}.{table_name}"
+                    )
+                    ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
 
-                overall_pbar = tqdm(
-                    total=len(all_to_process), desc="Synchronizing datasets"
-                )
+                    all_to_process = sorted(plan["to_update"] + plan["to_insert"])
+                    chunk_size = 5
 
-                for i in range(0, len(all_to_process), chunk_size):
-                    chunk = all_to_process[i : i + chunk_size]
-                    chunk_rows = sum([bq_info[ds_id][1] for ds_id in chunk])
+                    overall_pbar = tqdm(
+                        total=len(all_to_process),
+                        desc=f"  Table {table_name}",
+                        leave=True,
+                    )
 
-                    try:
-                        # Delete if update
-                        for ds_id in chunk:
-                            if ds_id in to_update:
-                                delete_dataset_from_pg(cursor, args.pg_table, ds_id)
+                    for i in range(0, len(all_to_process), chunk_size):
+                        chunk = all_to_process[i : i + chunk_size]
+                        chunk_rows = sum([plan["bq_info"][ds_id][1] for ds_id in chunk])
 
-                        # Build query for the chunk
-                        ds_ids_str = ", ".join([f"'{ds}'" for ds in chunk])
-                        bq_query = f"""
-                            SELECT *
-                            FROM `{args.bq_dataset}.{args.bq_table}`
-                            WHERE dataset_id IN ({ds_ids_str})
-                        """
+                        try:
+                            # Delete if update
+                            for ds_id in chunk:
+                                if ds_id in plan["to_update"]:
+                                    delete_dataset_from_pg(cursor, table_name, ds_id)
 
-                        # Stream directly from BQ to PG
-                        stream_bq_to_pg(
-                            cursor,
-                            args.pg_table,
-                            bq_client,
-                            bq_query,
-                            bq_table_obj.schema,
-                            chunk_rows,
-                        )
+                            # Build query for the chunk
+                            ds_ids_str = ", ".join([f"'{ds}'" for ds in chunk])
+                            bq_query = f"SELECT * FROM `{args.bq_dataset}.{table_name}` WHERE dataset_id IN ({ds_ids_str})"
 
-                        # Update sync states
-                        for ds_id in chunk:
-                            update_sync_state(
-                                cursor, args.pg_table, ds_id, bq_info[ds_id][0]
+                            # Stream directly from BQ to PG
+                            stream_bq_to_pg(
+                                cursor,
+                                table_name,
+                                bq_client,
+                                bq_query,
+                                bq_table_obj.schema,
+                                chunk_rows,
                             )
 
-                        # COMMIT EACH CHUNK
-                        conn.commit()
-                        overall_pbar.update(len(chunk))
+                            # Update sync states
+                            for ds_id in chunk:
+                                update_sync_state(
+                                    cursor, table_name, ds_id, plan["bq_info"][ds_id][0]
+                                )
 
-                    except (Exception, KeyboardInterrupt) as e:
-                        conn.rollback()
-                        overall_pbar.close()
-                        if isinstance(e, KeyboardInterrupt):
-                            logging.error(
-                                "\nSync interrupted by user. Rolling back current chunk..."
-                            )
-                        else:
-                            logging.error(f"\nError during sync: {e}. Rolling back...")
-                        sys.exit(1)
+                            # COMMIT EACH CHUNK
+                            conn.commit()
+                            overall_pbar.update(len(chunk))
 
-                overall_pbar.close()
-                logging.info("Sync completed successfully.")
+                        except (Exception, KeyboardInterrupt) as e:
+                            conn.rollback()
+                            overall_pbar.close()
+                            if isinstance(e, KeyboardInterrupt):
+                                logging.error(
+                                    f"\nSync of {table_name} interrupted. Rolling back current chunk..."
+                                )
+                            else:
+                                logging.error(
+                                    f"\nError syncing {table_name}: {e}. Rolling back..."
+                                )
+                            sys.exit(1)
+
+                    overall_pbar.close()
+
+                logging.info("Multi-table sync completed successfully.")
 
     except psycopg2.Error as e:
         logging.error(f"Postgres connection error: {e}")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -5,9 +5,7 @@ import enum
 import io
 import logging
 import os
-import sys
 import uuid
-import time
 from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Tuple, Optional, Any
@@ -191,7 +189,7 @@ def export_dataset_to_gcs(
             job_config=extract_config,
         )
         extract_job.result()
-    except (Exception, KeyboardInterrupt) as e:
+    except BaseException as e:
         if query_job and not query_job.done():
             logging.info("        Cancelling BigQuery query job...")
             query_job.cancel()
@@ -254,9 +252,10 @@ def _download_and_convert_blob(blob, bq_schema):
     return _prepare_table_for_copy(table, bq_schema)
 
 
-def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
+def load_parquet_from_gcs_to_pg(
+    cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema, gcs_client
+):
     """Loads Parquet files from GCS into Postgres using COPY."""
-    gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     logging.info(f"        Listing blobs in {gcs_prefix}...")
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
@@ -301,10 +300,9 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
     pbar.close()
 
 
-def cleanup_gcs(gcs_bucket, gcs_prefix):
+def cleanup_gcs(gcs_bucket, gcs_prefix, gcs_client):
     """Removes temporary files from GCS."""
     logging.info(f"      - Cleaning up GCS files...")
-    gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
     for blob in blobs:
@@ -398,9 +396,8 @@ def refresh_materialized_views(cursor, table_name, concurrently=False):
                 f"        Failed to refresh {view_name} {conc_clause.strip()}: {e}. Trying without CONCURRENTLY."
             )
             if concurrently:
-                cursor.connection.rollback()  # Required to recover from error in transaction if any (though we are usually autocommit here if using concurrent)
                 # If we were in a transaction block, we can't retry easily without rollback.
-                # Assuming this runs in a state where we can retry.
+                # Assuming this runs in a state where we can retry (autocommit=True for MV refresh).
                 cursor.execute(
                     sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
                         sql.Identifier(view_name)
@@ -428,6 +425,7 @@ class TableSynchronizer:
         self.bq_location = bq_location
         self.gcs_bucket = gcs_bucket
         self.bq_client = bigquery.Client()
+        self.gcs_client = storage.Client()
 
     def sync_table(self, table_name: str, plan: Dict[str, Any]):
         logging.info(f"Syncing table {table_name}...")
@@ -435,9 +433,7 @@ class TableSynchronizer:
             self._sync_unified(table_name, plan)
             logging.info(f"Successfully synced {table_name}.")
 
-        except Exception as e:
-            if isinstance(e, KeyboardInterrupt):
-                raise e
+        except BaseException as e:
             logging.error(f"Error syncing {table_name}: {e}.")
             raise e
 
@@ -465,9 +461,10 @@ class TableSynchronizer:
                 self.gcs_bucket,
                 gcs_prefix,
                 bq_schema,
+                self.gcs_client,
             )
         finally:
-            cleanup_gcs(self.gcs_bucket, gcs_prefix)
+            cleanup_gcs(self.gcs_bucket, gcs_prefix, self.gcs_client)
 
     def _sync_unified(self, table_name: str, plan: Dict[str, Any]):
         """
@@ -560,7 +557,7 @@ def main():
         with conn.cursor() as cursor:
             # fetch current state
             pg_states = get_all_sync_states(cursor)
-            bq_client = bigquery.Client()
+            bq_client = synchronizer.bq_client
 
             for table_name in TABLES_TO_SYNC:
                 logging.info(f"Checking {table_name}...")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -71,6 +71,12 @@ INDEX_DEFINITIONS = {
     ],
 }
 
+PERTURB_SEQ_DEA_MVIEWS = [
+    "perturb_seq_summary_perturbation",
+    "perturb_seq_summary_effect",
+    "perturb_seq_summary_dataset",
+]
+
 
 def get_pg_type(field):
     """Maps BigQuery types to PostgreSQL types."""
@@ -232,7 +238,9 @@ def _download_and_convert_blob(blob, bq_schema):
     return _prepare_table_for_copy(table, bq_schema)
 
 
-def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
+def load_parquet_from_gcs_to_pg(
+    cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema, debug_limit=None
+):
     """Loads Parquet files from GCS into Postgres using COPY.
 
     Uses concurrent GCS downloads and PyArrow's native C++ CSV writer for
@@ -246,6 +254,12 @@ def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_sch
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
+
+    if debug_limit:
+        logging.info(
+            f"        Debug limit set: reducing shards from {len(blobs)} to {debug_limit}"
+        )
+        blobs = blobs[:debug_limit]
 
     copy_sql = sql.SQL(
         "COPY {} FROM STDIN WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\"', NULL '')"
@@ -343,6 +357,7 @@ def drop_indexes(cursor, table_name):
         return
     logging.info(f"      - Dropping indexes for {table_name}...")
     for index_name, _ in INDEX_DEFINITIONS[table_name]:
+        logging.info(f"        Dropping {index_name}...")
         cursor.execute(
             sql.SQL("DROP INDEX IF EXISTS {}").format(sql.Identifier(index_name))
         )
@@ -355,8 +370,21 @@ def create_indexes(cursor, table_name):
     logging.info(
         f"      - Reinstating indexes for {table_name} (this may take a while)..."
     )
-    for _, index_sql in INDEX_DEFINITIONS[table_name]:
+    for index_name, index_sql in INDEX_DEFINITIONS[table_name]:
+        logging.info(f"        Creating {index_name}...")
         cursor.execute(index_sql)
+
+
+def refresh_materialized_views(cursor, table_name):
+    """Refreshes materialized views dependent on the table."""
+    if table_name == "perturb_seq_dea":
+        for view_name in PERTURB_SEQ_DEA_MVIEWS:
+            logging.info(f"      - Refreshing materialized view {view_name}...")
+            cursor.execute(
+                sql.SQL("REFRESH MATERIALIZED VIEW {}").format(
+                    sql.Identifier(view_name)
+                )
+            )
 
 
 def main():
@@ -373,13 +401,19 @@ def main():
         action="store_true",
         help="Drop indexes before loading and recreate them after (faster for bulk loads)",
     )
+    parser.add_argument(
+        "--debug-limit-N-shards",
+        type=int,
+        help="Only load the first N shards for every dataset (debugging)",
+    )
     args = parser.parse_args()
 
     bq_client = bigquery.Client()
 
     try:
-        with psycopg2.connect(args.pg_conn) as conn:
-            with conn.cursor() as cursor:
+        # Phase 1: Planning (Read-only / Meta-data fetch)
+        with psycopg2.connect(args.pg_conn) as plan_conn:
+            with plan_conn.cursor() as cursor:
                 # 1. Fetch current sync states for all tables
                 logging.info("Fetching current sync states from Postgres...")
                 all_states = get_all_sync_states(cursor)
@@ -416,121 +450,140 @@ def main():
                         }
                         total_datasets += len(to_update) + len(to_insert)
 
-                # 3. Summary and confirmation
-                if not sync_plan:
-                    logging.info("Everything is up to date. Nothing to sync.")
-                    return
+        # 3. Summary and confirmation
+        if not sync_plan:
+            logging.info("Everything is up to date. Nothing to sync.")
+            return
 
-                print("\n--- Sync Summary ---")
-                for table_name, plan in sync_plan.items():
-                    print(f"Table: {table_name}")
-                    if plan["to_update"]:
-                        print(f"  Datasets to update: {len(plan['to_update'])}")
-                        print(
-                            f"    {', '.join(plan['to_update'][:5])}{'...' if len(plan['to_update']) > 5 else ''}"
-                        )
-                    if plan["to_insert"]:
-                        print(f"  Datasets to insert: {len(plan['to_insert'])}")
-                        print(
-                            f"    {', '.join(plan['to_insert'][:5])}{'...' if len(plan['to_insert']) > 5 else ''}"
-                        )
-
-                print(f"\nTotal datasets to process: {total_datasets}")
-                print("--------------------\n")
-
-                if not args.yes:
-                    try:
-                        confirm = input("Proceed with sync? (y/N): ")
-                    except EOFError:
-                        confirm = "n"
-                    if confirm.lower() != "y":
-                        logging.info("Sync cancelled by user.")
-                        sys.exit(0)
-
-                # 4. Sequential Execution (one dataset at a time)
-                overall_pbar = tqdm(
-                    total=total_datasets, desc="Overall Progress", unit="dataset"
+        print("\n--- Sync Summary ---")
+        for table_name, plan in sync_plan.items():
+            print(f"Table: {table_name}")
+            if plan["to_update"]:
+                print(f"  Datasets to update: {len(plan['to_update'])}")
+                print(
+                    f"    {', '.join(plan['to_update'][:5])}{'...' if len(plan['to_update']) > 5 else ''}"
+                )
+            if plan["to_insert"]:
+                print(f"  Datasets to insert: {len(plan['to_insert'])}")
+                print(
+                    f"    {', '.join(plan['to_insert'][:5])}{'...' if len(plan['to_insert']) > 5 else ''}"
                 )
 
-                for table_name, plan in sync_plan.items():
-                    logging.info(f"Syncing table {table_name}...")
+        print(f"\nTotal datasets to process: {total_datasets}")
+        print("--------------------\n")
 
-                    bq_table_obj = bq_client.get_table(
-                        f"{args.bq_dataset}.{table_name}"
-                    )
-                    ensure_pg_table_exists(cursor, table_name, bq_table_obj.schema)
+        if not args.yes:
+            try:
+                confirm = input("Proceed with sync? (y/N): ")
+            except EOFError:
+                confirm = "n"
+            if confirm.lower() != "y":
+                logging.info("Sync cancelled by user.")
+                sys.exit(0)
 
-                    # Drop indexes before bulk update (if requested)
-                    if args.drop_and_recreate_indexes:
-                        drop_indexes(cursor, table_name)
+        # 4. Execution (Per-table connection and transaction)
+        overall_pbar = tqdm(
+            total=total_datasets, desc="Overall Progress", unit="dataset"
+        )
 
-                    all_to_process = sorted(plan["to_update"] + plan["to_insert"])
+        for table_name, plan in sync_plan.items():
+            logging.info(f"Syncing table {table_name}...")
 
-                    for ds_id in all_to_process:
-                        row_count = plan["bq_info"][ds_id][1]
-                        bq_timestamp = plan["bq_info"][ds_id][0]
+            try:
+                # Open a NEW connection for this table
+                conn = psycopg2.connect(args.pg_conn)
+                try:
+                    # Open a transaction block. If this block raises, it rolls back.
+                    # If it exits successfully, it commits.
+                    with conn:
+                        with conn.cursor() as cursor:
+                            bq_table_obj = bq_client.get_table(
+                                f"{args.bq_dataset}.{table_name}"
+                            )
+                            ensure_pg_table_exists(
+                                cursor, table_name, bq_table_obj.schema
+                            )
 
-                        try:
-                            # Delete if update
-                            if ds_id in plan["to_update"]:
-                                delete_dataset_from_pg(cursor, table_name, ds_id)
+                            # Drop indexes before bulk update (if requested)
+                            if args.drop_and_recreate_indexes:
+                                drop_indexes(cursor, table_name)
 
-                            # Parquet-based sync via GCS
-                            gcs_prefix = f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
-                            logging.info(f"    Processing {ds_id}:")
+                            all_to_process = sorted(
+                                plan["to_update"] + plan["to_insert"]
+                            )
 
-                            try:
-                                logging.info(
-                                    f"      - Exporting from BigQuery to GCS..."
+                            for ds_id in all_to_process:
+                                row_count = plan["bq_info"][ds_id][1]
+                                bq_timestamp = plan["bq_info"][ds_id][0]
+
+                                # Delete if update
+                                if ds_id in plan["to_update"]:
+                                    delete_dataset_from_pg(cursor, table_name, ds_id)
+
+                                # Parquet-based sync via GCS
+                                gcs_prefix = (
+                                    f"tmp/{table_name}/{ds_id}/{uuid.uuid4().hex}"
                                 )
-                                export_dataset_to_gcs(
-                                    bq_client,
-                                    args.bq_dataset,
-                                    table_name,
-                                    args.bq_location,
-                                    args.gcs_bucket,
-                                    gcs_prefix,
-                                    ds_id,
+                                logging.info(f"    Processing {ds_id}:")
+
+                                try:
+                                    logging.info(
+                                        f"      - Exporting from BigQuery to GCS..."
+                                    )
+                                    export_dataset_to_gcs(
+                                        bq_client,
+                                        args.bq_dataset,
+                                        table_name,
+                                        args.bq_location,
+                                        args.gcs_bucket,
+                                        gcs_prefix,
+                                        ds_id,
+                                    )
+
+                                    logging.info(
+                                        f"      - Loading from GCS to Postgres..."
+                                    )
+                                    load_parquet_from_gcs_to_pg(
+                                        cursor,
+                                        table_name,
+                                        args.gcs_bucket,
+                                        gcs_prefix,
+                                        bq_table_obj.schema,
+                                        debug_limit=args.debug_limit_N_shards,
+                                    )
+                                finally:
+                                    cleanup_gcs(args.gcs_bucket, gcs_prefix)
+
+                                # Update sync states
+                                update_sync_state(
+                                    cursor, table_name, ds_id, bq_timestamp
                                 )
 
-                                logging.info(f"      - Loading from GCS to Postgres...")
-                                load_parquet_from_gcs_to_pg(
-                                    cursor,
-                                    table_name,
-                                    args.gcs_bucket,
-                                    gcs_prefix,
-                                    bq_table_obj.schema,
-                                )
-                            finally:
-                                cleanup_gcs(args.gcs_bucket, gcs_prefix)
+                                overall_pbar.update(1)
 
-                            # Update sync states
-                            update_sync_state(cursor, table_name, ds_id, bq_timestamp)
+                            # Rebuild indexes after all data for this table is loaded
+                            if args.drop_and_recreate_indexes:
+                                create_indexes(cursor, table_name)
 
-                            overall_pbar.update(1)
+                            # Refresh materialized views dependent on this table
+                            refresh_materialized_views(cursor, table_name)
 
-                        except (Exception, KeyboardInterrupt) as e:
-                            conn.rollback()
-                            overall_pbar.close()
-                            if isinstance(e, KeyboardInterrupt):
-                                logging.error(
-                                    f"\nSync of {table_name}/{ds_id} interrupted. Rolling back..."
-                                )
-                            else:
-                                logging.error(
-                                    f"\nError syncing {table_name}/{ds_id}: {e}. Rolling back..."
-                                )
-                            sys.exit(1)
+                    # Transaction commits here automatically for this table.
+                    logging.info(f"Successfully synced {table_name}.")
 
-                    # Rebuild indexes after all data for this table is loaded
-                    if args.drop_and_recreate_indexes:
-                        create_indexes(cursor, table_name)
+                finally:
+                    conn.close()
 
-                    # COMMIT ONCE PER TABLE
-                    conn.commit()
+            except Exception as e:
+                # This catches errors for THIS table's transaction.
+                # The 'with conn:' block already rolled back the DB transaction.
+                # We log the error and continue to the next table.
+                if isinstance(e, KeyboardInterrupt):
+                    raise e  # Allow Ctrl+C to stop everything
+                logging.error(f"Error syncing {table_name}: {e}. Skipping this table.")
 
-                overall_pbar.close()
-                logging.info("Multi-table sync completed successfully.")
+        overall_pbar.close()
+        logging.info("Multi-table sync operations completed.")
 
     except psycopg2.Error as e:
         logging.error(f"Postgres connection error: {e}")

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -1,12 +1,17 @@
 import argparse
+import concurrent.futures
 import logging
 import io
+import os
 import sys
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from google.cloud import bigquery, storage
 import psycopg2
 from psycopg2 import sql
 from tqdm import tqdm
+import pyarrow as pa
+import pyarrow.csv as pa_csv
 import pyarrow.parquet as pq
 
 
@@ -118,26 +123,9 @@ def get_bq_latest_timestamps_and_counts(bq_client, bq_dataset, bq_table, bq_loca
     return {row.dataset_id: (row.latest_ts, row.row_count) for row in results}
 
 
-def format_row(row, schema):
-    """Formats a row for Postgres COPY command (TSV)."""
-    formatted = []
-    for i, field in enumerate(schema):
-        val = row[i]
-        if val is None:
-            formatted.append("")
-        elif field.mode == "REPEATED":
-            # Convert list to Postgres array literal: {"val1", "val2"}
-            inner = [str(x) if not isinstance(x, str) else x for x in val]
-            escaped = []
-            for x in inner:
-                x_str = str(x).replace('"', '\\"')
-                escaped.append(f'"{x_str}"')
-            formatted.append(f'{{{",".join(escaped)}}}')
-        elif field.field_type == "BOOLEAN":
-            formatted.append("true" if val else "false")
-        else:
-            formatted.append(str(val))
-    return "\t".join(formatted)
+# Number of threads for concurrent GCS blob download + Parquet-to-CSV conversion.
+# Auto-detected from available CPUs; each worker holds one shard in memory.
+GCS_DOWNLOAD_WORKERS = os.cpu_count() or 4
 
 
 def export_dataset_to_gcs(
@@ -185,31 +173,118 @@ def export_dataset_to_gcs(
     return destination_uri
 
 
+def _convert_array_column(col):
+    """Convert a PyArrow list-typed column to Postgres array literal strings.
+
+    E.g. ["a", "b"] -> '{"a","b"}'
+    """
+    result = []
+    for val in col.to_pylist():
+        if val is None:
+            result.append(None)
+        else:
+            escaped = []
+            for x in val:
+                x_str = str(x).replace("\\", "\\\\").replace('"', '\\"')
+                escaped.append(f'"{ x_str}"')
+            result.append("{" + ",".join(escaped) + "}")
+    return pa.array(result, type=pa.string())
+
+
+def _prepare_table_for_copy(table, bq_schema):
+    """Prepare a PyArrow table for Postgres COPY: handle array columns and
+    convert to a CSV (tab-delimited) bytes buffer using PyArrow's C++ writer.
+    """
+    # Build a set of array column names for targeted conversion
+    array_cols = {f.name for f in bq_schema if f.mode == "REPEATED"}
+
+    if array_cols:
+        new_columns = []
+        for i, name in enumerate(table.column_names):
+            col = table.column(i)
+            if name in array_cols:
+                new_columns.append(_convert_array_column(col))
+            else:
+                new_columns.append(col)
+        table = pa.table(
+            {name: col for name, col in zip(table.column_names, new_columns)}
+        )
+
+    # Write to TSV bytes buffer using PyArrow's C++ CSV writer (very fast)
+    buf = io.BytesIO()
+    write_options = pa_csv.WriteOptions(
+        include_header=False,
+        delimiter="\t",
+    )
+    pa_csv.write_csv(table, buf, write_options=write_options)
+    buf.seek(0)
+    return buf
+
+
+def _download_and_convert_blob(blob, bq_schema):
+    """Download a single Parquet shard from GCS and convert to a TSV buffer.
+
+    This runs in a worker thread to overlap GCS I/O with CPU work.
+    Returns a BytesIO buffer ready for COPY FROM STDIN.
+    """
+    data = blob.download_as_bytes()
+    table = pq.read_table(io.BytesIO(data))
+    return _prepare_table_for_copy(table, bq_schema)
+
+
 def load_parquet_from_gcs_to_pg(cursor, pg_table, gcs_bucket, gcs_prefix, bq_schema):
-    """Loads Parquet files from GCS into Postgres using COPY."""
+    """Loads Parquet files from GCS into Postgres using COPY.
+
+    Uses concurrent GCS downloads and PyArrow's native C++ CSV writer for
+    maximum throughput. Blobs are downloaded and converted to TSV in parallel
+    threads; the main thread feeds buffers to Postgres sequentially.
+
+    Memory is bounded: at most ``GCS_DOWNLOAD_WORKERS`` shard buffers exist in
+    memory at any time. New work is only submitted as previous results are
+    consumed by Postgres COPY.
+    """
     gcs_client = storage.Client()
     bucket = gcs_client.get_bucket(gcs_bucket)
     blobs = list(bucket.list_blobs(prefix=gcs_prefix))
 
-    for blob in tqdm(blobs, desc="        Loading shards", leave=False):
-        with blob.open("rb") as f:
-            parquet_file = pq.ParquetFile(f)
-            for i in range(parquet_file.num_row_groups):
-                table = parquet_file.read_row_group(i)
-                rows = table.to_pylist()
+    copy_sql = sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
+        sql.Identifier(pg_table)
+    )
 
-                tsv_data = io.StringIO()
-                for row_dict in rows:
-                    row_val = [row_dict.get(field.name) for field in bq_schema]
-                    tsv_data.write(format_row(row_val, bq_schema) + "\n")
+    max_workers = GCS_DOWNLOAD_WORKERS
+    blob_iter = iter(blobs)
+    pbar = tqdm(total=len(blobs), desc="        Loading shards", leave=False)
 
-                tsv_data.seek(0)
-                cursor.copy_expert(
-                    sql.SQL("COPY {} FROM STDIN WITH (FORMAT TEXT, NULL '')").format(
-                        sql.Identifier(pg_table)
-                    ),
-                    tsv_data,
-                )
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        # Seed the pool with an initial batch (bounded to max_workers)
+        pending = {}
+        for blob in iter(lambda: next(blob_iter, None), None):
+            fut = pool.submit(_download_and_convert_blob, blob, bq_schema)
+            pending[fut] = blob
+            if len(pending) >= max_workers:
+                break
+
+        # Sliding window: consume one result, submit one new blob
+        while pending:
+            done, _ = concurrent.futures.wait(
+                pending, return_when=concurrent.futures.FIRST_COMPLETED
+            )
+            for fut in done:
+                tsv_buf = fut.result()
+                cursor.copy_expert(copy_sql, tsv_buf)
+                tsv_buf.close()
+                del pending[fut]
+                pbar.update(1)
+
+                # Submit next blob if available
+                next_blob = next(blob_iter, None)
+                if next_blob is not None:
+                    new_fut = pool.submit(
+                        _download_and_convert_blob, next_blob, bq_schema
+                    )
+                    pending[new_fut] = next_blob
+
+    pbar.close()
 
 
 def cleanup_gcs(gcs_bucket, gcs_prefix):

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -8,6 +8,7 @@ import os
 import sys
 import uuid
 import time
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Tuple, Optional, Any
 
@@ -580,6 +581,8 @@ def main():
                         to_insert.append(ds_id)
                     else:
                         pg_ts = pg_info[ds_id]
+                        if pg_ts and pg_ts.tzinfo is None:
+                            pg_ts = pg_ts.replace(tzinfo=timezone.utc)
                         if bq_ts > pg_ts:
                             to_update.append(ds_id)
 

--- a/dwh/postgres/bq_to_postgres.py
+++ b/dwh/postgres/bq_to_postgres.py
@@ -356,7 +356,7 @@ def drop_indexes(cursor, table_name, suffix=""):
     """Drops all indexes for a given table based on INDEX_DEFINITIONS."""
     if table_name not in INDEX_DEFINITIONS:
         return
-    logging.info(f"      - Dropping indexes for {table_name}{suffix}...")
+    logging.info(f"    Dropping indexes for {table_name}{suffix}...")
     for index_name, _ in INDEX_DEFINITIONS[table_name]:
         idx = f"{index_name}{suffix}"
         logging.info(f"        Dropping {idx}...")


### PR DESCRIPTION
This is a major refactor for the BQ to Postgres sync approach, and part of wider data workflow pipeline refactor.

* The script now computes diff and syncs *all* relevant tables, not just the specified ones: less manual actions
* Synchronisation is more granular, using the `dataset_id` for every given table.
* If a dataset is found to be *modified* (already in Postgres, but latest change is later than sync time), it is automatically deleted from Postgres and reingested.
* Transactional safety is ensured for data synchronisation.
* The `--drop-and-recreate-indexes` option is added for performance. For all but the smallest datasets it's necessary, because adding new rows into an already indexed table is extremely slow.