### PR TITLE
Make it possible to suppress datasets when running DBT

### DIFF
--- a/dwh/bq_dbt/README.md
+++ b/dwh/bq_dbt/README.md
@@ -31,3 +31,7 @@ These commands should be run from this directory, `bq_dbt`.
 - A specific model and its upstream dependencies: `dbt run --select +dataset_summary`
 - A specific model and its upstream dependencies with full refresh: `dbt run --full-refresh --select +dataset_summary`. For example, this is needed if the schema has changed and all data needs to be reingested, not only the new rows.
 - Full refresh of all models (non-incremental): `dbt run --full-refresh`
+
+### Suppress datasets
+To exclude specific datasets from `unified_metadata` and downstream summary tables (while keeping them in data tables), use the `suppress_datasets` variable:
+`dbt run --vars '{"suppress_datasets": "dataset_id_1,dataset_id_2"}'`

--- a/dwh/bq_dbt/models/unified_metadata.sql
+++ b/dwh/bq_dbt/models/unified_metadata.sql
@@ -17,3 +17,11 @@ with
 
 select *
 from unified
+{% if var('suppress_datasets', None) %}
+    where dataset_id not in (
+        {% set suppressed_ids = var('suppress_datasets').split(',') %}
+        {% for id in suppressed_ids %}
+            '{{ id | trim }}'{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    )
+{% endif %}


### PR DESCRIPTION
This is often useful when we temporarily don't want to display a particular dataset, such as when some of the code or infrastructure is not ready.

Suppression happens on the level of *metadata*. This is sufficient because datapoints from Postgres can never be returned unless there's a corresponding entry in the metadata indexes.