### PR TITLE
Fix three issues which caused target count mismatches

### DIFF
--- a/dwh/bq_dbt/models/landing_page_summary.sql
+++ b/dwh/bq_dbt/models/landing_page_summary.sql
@@ -77,7 +77,7 @@ with
             count(distinct experiment_title) as n_experiments,
             min(study_year) as min_year,
             max(study_year) as max_year,
-            count(distinct perturbed_target_symbol) as n_targets,
+            (select count(distinct perturbed_target_symbol) from {{ ref("target_summary") }}) as n_targets,
             count(distinct tissue_label) as n_tissues,
             count(distinct cell_type_label) as n_cell_types,
             count(distinct cell_line_label) as n_cell_lines,

--- a/dwh/bq_dbt/models/landing_page_summary.sql
+++ b/dwh/bq_dbt/models/landing_page_summary.sql
@@ -77,7 +77,7 @@ with
             count(distinct experiment_title) as n_experiments,
             min(study_year) as min_year,
             max(study_year) as max_year,
-            (select count(distinct perturbed_target_symbol) from {{ ref("target_summary") }}) as n_targets,
+            count(distinct perturbed_target_symbol) as n_targets,
             count(distinct tissue_label) as n_tissues,
             count(distinct cell_type_label) as n_cell_types,
             count(distinct cell_line_label) as n_cell_lines,

--- a/dwh/bq_dbt/models/landing_page_summary.sql
+++ b/dwh/bq_dbt/models/landing_page_summary.sql
@@ -77,7 +77,7 @@ with
             count(distinct experiment_title) as n_experiments,
             min(study_year) as min_year,
             max(study_year) as max_year,
-            count(distinct perturbed_target_ensg) as n_targets,
+            count(distinct perturbed_target_symbol) as n_targets,
             count(distinct tissue_label) as n_tissues,
             count(distinct cell_type_label) as n_cell_types,
             count(distinct cell_line_label) as n_cell_lines,

--- a/dwh/bq_dbt/models/target_summary.sql
+++ b/dwh/bq_dbt/models/target_summary.sql
@@ -66,7 +66,7 @@ with
 
     -- Supersets of symbols to ensure we don't miss any target that might exist only
     -- in data (unlikely but safe)
-    symbols as (
+    symbols_raw as (
         select perturbed_target_symbol
         from agg_meta
         union distinct
@@ -81,6 +81,9 @@ with
         union distinct
         select perturbed_target_symbol
         from agg_gsea
+    ),
+    symbols as (
+        select * from symbols_raw where perturbed_target_symbol is not null
     )
 
 select

--- a/dwh/bq_dbt/models/unified_metadata.sql
+++ b/dwh/bq_dbt/models/unified_metadata.sql
@@ -10,9 +10,16 @@ with
         union all by name
         select distinct * except (sample_id)
         from {{ source("perturb_seq", "metadata") }}
-        where
-            perturbed_target_symbol not like 'control%'
-            and perturbed_target_symbol not like '%None%'
+        where not (
+            -- Exclude rows where every '|' separated part contains 'control',
+            -- meaning that the sample *only* contains controls.
+            array_size(
+                array_filter(
+                    split(perturbed_target_symbol, '|'),
+                    x -> lower(x) not like '%control%'
+                )
+            ) = 0
+        )
     )
 
 select *

--- a/dwh/bq_dbt/models/unified_metadata.sql
+++ b/dwh/bq_dbt/models/unified_metadata.sql
@@ -11,7 +11,8 @@ with
         select distinct * except (sample_id)
         from {{ source("perturb_seq", "metadata") }}
         where not (
-            -- Exclude rows where EVERY '|' separated part contains "control"
+            -- Exclude rows where EVERY '|' separated part contains "control",
+            -- meaning that the sample *only* contains controls.
             not exists (
                 select 1
                 from unnest(split(perturbed_target_symbol, '|')) as part

--- a/dwh/bq_dbt/models/unified_metadata.sql
+++ b/dwh/bq_dbt/models/unified_metadata.sql
@@ -11,14 +11,12 @@ with
         select distinct * except (sample_id)
         from {{ source("perturb_seq", "metadata") }}
         where not (
-            -- Exclude rows where every '|' separated part contains 'control',
-            -- meaning that the sample *only* contains controls.
-            array_size(
-                array_filter(
-                    split(perturbed_target_symbol, '|'),
-                    x -> lower(x) not like '%control%'
-                )
-            ) = 0
+            -- Exclude rows where EVERY '|' separated part contains "control"
+            not exists (
+                select 1
+                from unnest(split(perturbed_target_symbol, '|')) as part
+                where lower(part) not like '%control%'
+            )
         )
     )
 


### PR DESCRIPTION
> [!NOTE] 
> **This PR is independent of the other ones and can be merged right away if approved. The metadata in Elastic is already updated.**

Fixes three issues which led to target count mismatches:

1. In `landing_page_summary`, use perturbed target **symbol** instead of perturbed target **ENSG.** This is because for now, the main identifier and grouping value for targets is the symbol, and using ENSG creates discrepancies (not every target has ENSG, for example).
2. In `landing_page_summary`, when counting targets, select them from `target_summary`, not `unified_metadata`. This is because target_summary unifies several sources, not *just* the ones mentioned in unified_metadata, and hence has a higher number of targets.
3. In `target_summary`, filter out the NULL target symbol value which appears from the multiple sources which are unified.