### PR TITLE
Refactor BQ to Elastic projector to make it fully automated

### DIFF
--- a/dwh/bq_to_es_projector/README.md
+++ b/dwh/bq_to_es_projector/README.md
@@ -1,31 +1,28 @@
 # BigQuery to Elasticsearch projector
 
-## Environment configuration
+## Running the projector
 
 These commands should be run from the parent directory, `dwh`.
+
+The script is automated and will:
+1. Load the three tables (`dataset_summary`, `target_summary`, and `landing_page_summary`) into Elastic under the format `YYYY-MM-DD-index-name`.
+2. If the sync is successful, move aliases such as `dataset-summary` to point to the latest index version.
+3. If the sync is successful, prune old index versions to keep only the live one + up to two earlier versions. 
 
 ```python
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 cd bq_to_es_projector
+dev_secrets
+python3 bq_to_es_projector.py
 ```
 
-## Running the projector
+## Additional configuration
 
-These commands should be run from the current directory, `bq_to_es_projector`.
-
-First, load environment variables using `dev_secrets`.
-
-Then, additionally set the following variables:
-* BQ_TABLE: which BQ table to ingest from, for example `dataset_summary`.
-* ES_INDEX: which Elastic index to ingest to in the format `YYYY-MM-DD-dataset-summary`. Note that the name of the index must be at the end of the string.
-
-Optional parameters that can also be set using environmental variables include:
+Optional parameters that can be set using environmental variables:
 ```bash
 BULK_CHUNK_SIZE=2000
 BULK_MAX_RETRIES=5
 BULK_TIMEOUT=120
 ```
-
-Finally, run the projector: `python bq_to_es_projector.py`.

--- a/dwh/bq_to_es_projector/README.md
+++ b/dwh/bq_to_es_projector/README.md
@@ -9,7 +9,7 @@ The script is automated and will:
 2. If the sync is successful, move aliases such as `dataset-summary` to point to the latest index version.
 3. If the sync is successful, prune old index versions to keep only the live one + up to two earlier versions. 
 
-```python
+```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt

--- a/dwh/bq_to_es_projector/bq_to_es_projector.py
+++ b/dwh/bq_to_es_projector/bq_to_es_projector.py
@@ -73,16 +73,6 @@ def make_es_client() -> Elasticsearch:
     return es
 
 
-def get_index_metadata(index_base: str) -> Tuple[str, str]:
-    """
-    Returns (index_prefix, key_field_name) for a given ES base index name.
-    """
-    for cfg in TABLE_CONFIG.values():
-        if cfg["index_base"] == index_base:
-            return cfg["prefix"], cfg["key_field"]
-    raise ValueError(f"Unknown index base: {index_base}")
-
-
 def generate_dataset_summary_mapping() -> Dict[str, Any]:
     """Dynamically generate mapping for dataset-summary from be/dataset_metadata.json"""
     mapping = {
@@ -103,8 +93,6 @@ def generate_dataset_summary_mapping() -> Dict[str, Any]:
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     metadata_path = os.path.join(script_dir, "../../be/dataset_metadata.json")
-    if not os.path.exists(metadata_path):
-        metadata_path = "dataset_metadata.json"
 
     with open(metadata_path, "r") as f:
         meta = json.load(f)
@@ -135,7 +123,12 @@ def generate_dataset_summary_mapping() -> Dict[str, Any]:
 def get_mapping(index_prefix: str) -> Dict[str, Any]:
     if index_prefix == "dataset":
         return generate_dataset_summary_mapping()
-    mapping_file = f"{index_prefix}-summary_settings+mapping.json"
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    mapping_file = os.path.join(
+        script_dir, f"{index_prefix}-summary_settings+mapping.json"
+    )
+
     if not os.path.exists(mapping_file):
         raise FileNotFoundError(f"Mapping file not found: {mapping_file}")
     with open(mapping_file, "r") as f:
@@ -201,7 +194,7 @@ def _coerce_num(v, to_float=False):
 
 
 def transform_row(
-    row: Dict[str, Any], es_index: str, prefix: str, key_field: str
+    row: Dict[str, Any], prefix: str, key_field: str
 ) -> Tuple[str, Dict[str, Any]]:
     """
     Convert a BQ row to ES document.
@@ -252,7 +245,7 @@ def actions_generator(
 ) -> Iterable[Dict[str, Any]]:
     for row in rows_iter:
         try:
-            _id, doc = transform_row(row, es_index, prefix, key_field)
+            _id, doc = transform_row(row, prefix, key_field)
             yield {"_op_type": "index", "_index": es_index, "_id": _id, "_source": doc}
         except ValueError:
             pass
@@ -267,7 +260,7 @@ def prune_old_indexes(es: Elasticsearch) -> None:
     index_bases = [cfg["index_base"] for cfg in TABLE_CONFIG.values()]
 
     for base in index_bases:
-        pattern = f"*-{base}"
+        pattern = f"????-??-??-{base}"
         try:
             indices = es.indices.get(index=pattern).body
         except ApiError:
@@ -292,7 +285,10 @@ def prune_old_indexes(es: Elasticsearch) -> None:
             continue
 
         # Since live is the latest, we keep it + 2 previous versions (first 3 in sorted list)
-        to_keep = index_names[:3]
+        to_keep = set(index_names[:3])
+        if live_index:
+            to_keep.add(live_index)
+
         to_delete = [idx for idx in index_names if idx not in to_keep]
 
         for idx in to_delete:
@@ -305,8 +301,13 @@ def main() -> int:
         logging.error("ES_URL is not set")
         return 2
 
+    if not BQ_PROJECT or not BQ_DATASET:
+        logging.error("GCLOUD_PROJECT and BQ_DATASET must be set")
+        return 2
+
     date_str = datetime.datetime.now().strftime("%Y-%m-%d")
     es = make_es_client()
+    bq_client = bigquery.Client(project=BQ_PROJECT)
 
     sync_results = {}  # index_base -> new_index
 
@@ -330,7 +331,6 @@ def main() -> int:
             ensure_index(es, es_index, prefix)
 
             # Use BigQuery client to get total row count for progress bar
-            bq_client = bigquery.Client(project=BQ_PROJECT)
             table_ref = f"{BQ_PROJECT}.{BQ_DATASET}.{table}"
             bq_table = bq_client.get_table(table_ref)
             total_rows = bq_table.num_rows
@@ -349,7 +349,7 @@ def main() -> int:
                     pbar.update(1)
                     yield action
 
-            success, errors = helpers.bulk(
+            success, bulk_errors = helpers.bulk(
                 es.options(request_timeout=BULK_TIMEOUT),
                 actions_with_progress(),
                 chunk_size=BULK_CHUNK_SIZE,
@@ -359,8 +359,10 @@ def main() -> int:
             )
             pbar.close()
 
-            if errors:
-                sample = errors[:5] if isinstance(errors, list) else errors
+            if bulk_errors:
+                sample = (
+                    bulk_errors[:5] if isinstance(bulk_errors, list) else bulk_errors
+                )
                 logging.error(
                     "Bulk completed with item errors. Sample: %s",
                     json.dumps(sample, indent=2)[:1200],

--- a/dwh/bq_to_es_projector/bq_to_es_projector.py
+++ b/dwh/bq_to_es_projector/bq_to_es_projector.py
@@ -14,6 +14,7 @@ import sys
 import json
 import logging
 import datetime
+import re
 from typing import Any, Dict, Iterable, Tuple
 
 from google.cloud import bigquery
@@ -260,16 +261,21 @@ def prune_old_indexes(es: Elasticsearch) -> None:
     index_bases = [cfg["index_base"] for cfg in TABLE_CONFIG.values()]
 
     for base in index_bases:
-        pattern = f"????-??-??-{base}"
+        pattern = f"*-{base}"
         try:
             indices = es.indices.get(index=pattern).body
+            all_names = sorted(indices.keys(), reverse=True)
+            # Specifically match YYYY-MM-DD-index-name
+            regex = re.compile(r"^\d{4}-\d{2}-\d{2}-" + re.escape(base) + r"$")
+            index_names = [n for n in all_names if regex.match(n)]
         except ApiError:
-            logging.info("No indexes found for %s", base)
-            continue
+            index_names = []
 
-        # Sort indices by name (YYYY-MM-DD prefix) descending
-        index_names = sorted(indices.keys(), reverse=True)
         if not index_names:
+            logging.error(
+                "No indices found for %s! This is unexpected as there should be at least the live version.",
+                base,
+            )
             continue
 
         # Find the live index (pointed to by the alias)
@@ -279,10 +285,8 @@ def prune_old_indexes(es: Elasticsearch) -> None:
         except ApiError:
             live_index = None
 
-        logging.info("Index %s: live version is %s", base, live_index)
-
         if not live_index:
-            continue
+            logging.warning("No live index found for alias %s", base)
 
         # Since live is the latest, we keep it + 2 previous versions (first 3 in sorted list)
         to_keep = set(index_names[:3])
@@ -291,9 +295,22 @@ def prune_old_indexes(es: Elasticsearch) -> None:
 
         to_delete = [idx for idx in index_names if idx not in to_keep]
 
-        for idx in to_delete:
-            logging.info("Deleting old index: %s", idx)
-            es.indices.delete(index=idx)
+        if not to_delete:
+            logging.info(
+                "3 or less total versions found for %s and all kept: %s",
+                base,
+                ", ".join(sorted(list(to_keep))),
+            )
+        else:
+            logging.info(
+                "More than 3 versions found for %s. Keeping: %s. Pruning: %s",
+                base,
+                ", ".join(sorted(list(to_keep))),
+                ", ".join(to_delete),
+            )
+            for idx in to_delete:
+                logging.info("Deleting old index: %s", idx)
+                es.indices.delete(index=idx)
 
 
 def main() -> int:

--- a/dwh/bq_to_es_projector/bq_to_es_projector.py
+++ b/dwh/bq_to_es_projector/bq_to_es_projector.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, Tuple
 
 from google.cloud import bigquery
 from elasticsearch import Elasticsearch, helpers, ApiError
+from tqdm import tqdm
 
 # ---------------- Config ----------------
 BQ_PROJECT = os.getenv("GCLOUD_PROJECT")
@@ -54,6 +55,10 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
 )
 
+# Silence noisy dependency logs
+logging.getLogger("elastic_transport").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
 
 # ------------- ES client ----------------
 def make_es_client() -> Elasticsearch:
@@ -63,7 +68,7 @@ def make_es_client() -> Elasticsearch:
         ES_URL,
         basic_auth=(ES_USER, ES_PASS),
         request_timeout=BULK_TIMEOUT,
-        verify_certs=False,
+        verify_certs=True,
     )
     return es
 
@@ -316,19 +321,44 @@ def main() -> int:
         logging.info("Starting sync for %s -> %s", table, es_index)
 
         try:
+            # If current date index already exists, delete it first
+            if es.indices.exists(index=es_index):
+                logging.info(
+                    "Index %s already exists for today. Deleting it first...", es_index
+                )
+                es.indices.delete(index=es_index)
+
             ensure_index(es, es_index, prefix)
+
+            # Use BigQuery client to get total row count for progress bar
+            bq_client = bigquery.Client(project=BQ_PROJECT)
+            table_ref = f"{BQ_PROJECT}.{BQ_DATASET}.{table}"
+            bq_table = bq_client.get_table(table_ref)
+            total_rows = bq_table.num_rows
+
             rows_iter = stream_rows_from_bq(BQ_PROJECT, BQ_DATASET, table)
 
-            logging.info("Starting bulk indexing into %s …", es_index)
+            logging.info(
+                "Starting bulk indexing into %s (total: %s) …", es_index, total_rows
+            )
+
+            pbar = tqdm(total=total_rows, desc=table, unit="rows")
+
+            def actions_with_progress():
+                for action in actions_generator(rows_iter, es_index, prefix, key_field):
+                    pbar.update(1)
+                    yield action
+
             success, errors = helpers.bulk(
                 es,
-                actions_generator(rows_iter, es_index, prefix, key_field),
+                actions_with_progress(),
                 chunk_size=BULK_CHUNK_SIZE,
                 max_retries=BULK_MAX_RETRIES,
                 request_timeout=BULK_TIMEOUT,
                 raise_on_error=False,
                 stats_only=False,
             )
+            pbar.close()
 
             if errors:
                 sample = errors[:5] if isinstance(errors, list) else errors

--- a/dwh/bq_to_es_projector/bq_to_es_projector.py
+++ b/dwh/bq_to_es_projector/bq_to_es_projector.py
@@ -165,7 +165,6 @@ def stream_rows_from_bq(
 ) -> Iterable[Dict[str, Any]]:
     client = bigquery.Client(project=project)
     table_ref = f"{project}.{dataset}.{table}"
-    logging.info("Reading BigQuery rows: %s", table_ref)
     for row in client.list_rows(table_ref):
         yield dict(row)
 
@@ -341,6 +340,7 @@ def main() -> int:
             logging.info(
                 "Starting bulk indexing into %s (total: %s) …", es_index, total_rows
             )
+            logging.info("Reading BigQuery rows: %s", table_ref)
 
             pbar = tqdm(total=total_rows, desc=table, unit="rows")
 
@@ -350,11 +350,10 @@ def main() -> int:
                     yield action
 
             success, errors = helpers.bulk(
-                es,
+                es.options(request_timeout=BULK_TIMEOUT),
                 actions_with_progress(),
                 chunk_size=BULK_CHUNK_SIZE,
                 max_retries=BULK_MAX_RETRIES,
-                request_timeout=BULK_TIMEOUT,
                 raise_on_error=False,
                 stats_only=False,
             )

--- a/dwh/bq_to_es_projector/bq_to_es_projector.py
+++ b/dwh/bq_to_es_projector/bq_to_es_projector.py
@@ -13,6 +13,7 @@ import os
 import sys
 import json
 import logging
+import datetime
 from typing import Any, Dict, Iterable, Tuple
 
 from google.cloud import bigquery
@@ -21,10 +22,26 @@ from elasticsearch import Elasticsearch, helpers, ApiError
 # ---------------- Config ----------------
 BQ_PROJECT = os.getenv("GCLOUD_PROJECT")
 BQ_DATASET = os.getenv("BQ_DATASET")
-BQ_TABLE = os.getenv("BQ_TABLE")
+
+TABLE_CONFIG = {
+    "dataset_summary": {
+        "index_base": "dataset-summary",
+        "key_field": "dataset_id",
+        "prefix": "dataset",
+    },
+    "target_summary": {
+        "index_base": "target-summary",
+        "key_field": "perturbed_target_symbol",
+        "prefix": "target",
+    },
+    "landing_page_summary": {
+        "index_base": "landing-page-summary",
+        "key_field": "summary",
+        "prefix": "landing-page",
+    },
+}
 
 ES_URL = (os.getenv("ES_URL") or "").rstrip("/")
-ES_INDEX = os.getenv("ES_INDEX")
 
 ES_USER = os.getenv("ES_USERNAME")
 ES_PASS = os.getenv("ES_PASSWORD")
@@ -51,18 +68,14 @@ def make_es_client() -> Elasticsearch:
     return es
 
 
-def get_index_metadata(es_index_name: str) -> Tuple[str, str]:
+def get_index_metadata(index_base: str) -> Tuple[str, str]:
     """
-    Returns (index_prefix, key_field_name) for a given ES index name.
+    Returns (index_prefix, key_field_name) for a given ES base index name.
     """
-    if es_index_name.endswith("dataset-summary"):
-        return "dataset", "dataset_id"
-    elif es_index_name.endswith("target-summary"):
-        return "target", "perturbed_target_symbol"
-    elif es_index_name.endswith("landing-page-summary"):
-        return "landing-page", "summary"
-    else:
-        raise ValueError(f"Unknown index name: {es_index_name}")
+    for cfg in TABLE_CONFIG.values():
+        if cfg["index_base"] == index_base:
+            return cfg["prefix"], cfg["key_field"]
+    raise ValueError(f"Unknown index base: {index_base}")
 
 
 def generate_dataset_summary_mapping() -> Dict[str, Any]:
@@ -124,14 +137,13 @@ def get_mapping(index_prefix: str) -> Dict[str, Any]:
         return json.load(f)
 
 
-def ensure_index(es: Elasticsearch, index: str) -> None:
+def ensure_index(es: Elasticsearch, index: str, prefix: str) -> None:
     try:
         if es.indices.exists(index=index):
             logging.info("Index %s exists.", index)
             return
 
         logging.info("Index %s does not exist. Creating...", index)
-        prefix, _ = get_index_metadata(index)
         mapping_body = get_mapping(prefix)
 
         es.indices.create(index=index, body=mapping_body)
@@ -184,13 +196,14 @@ def _coerce_num(v, to_float=False):
         return v
 
 
-def transform_row(row: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+def transform_row(
+    row: Dict[str, Any], es_index: str, prefix: str, key_field: str
+) -> Tuple[str, Dict[str, Any]]:
     """
     Convert a BQ row to ES document.
     Ensures numerics are numeric and nested arrays are cleaned.
     """
     doc: Dict[str, Any] = {}
-    index_prefix, key_field = get_index_metadata(ES_INDEX)
 
     if key_field != "summary":
         symbol = row.get(key_field)
@@ -199,9 +212,7 @@ def transform_row(row: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
     else:
         symbol = "summary"
 
-    numeric_int_fields, numeric_float_fields, nested_fields = get_typed_fields(
-        index_prefix
-    )
+    numeric_int_fields, numeric_float_fields, nested_fields = get_typed_fields(prefix)
     for k, v in row.items():
         if k in numeric_int_fields:
             doc[k] = _coerce_num(v)
@@ -232,46 +243,130 @@ def transform_row(row: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
     return symbol, doc
 
 
-def actions_generator(rows_iter: Iterable[Dict[str, Any]]) -> Iterable[Dict[str, Any]]:
+def actions_generator(
+    rows_iter: Iterable[Dict[str, Any]], es_index: str, prefix: str, key_field: str
+) -> Iterable[Dict[str, Any]]:
     for row in rows_iter:
         try:
-            _id, doc = transform_row(row)
-            yield {"_op_type": "index", "_index": ES_INDEX, "_id": _id, "_source": doc}
+            _id, doc = transform_row(row, es_index, prefix, key_field)
+            yield {"_op_type": "index", "_index": es_index, "_id": _id, "_source": doc}
         except ValueError:
             pass
 
 
-# ----------------- Main ------------------
+def prune_old_indexes(es: Elasticsearch) -> None:
+    """
+    Prune indexes for the summary families.
+    Keep live version (pointed by alias) + up to 2 older versions.
+    """
+    logging.info("Starting index pruning...")
+    index_bases = [cfg["index_base"] for cfg in TABLE_CONFIG.values()]
+
+    for base in index_bases:
+        pattern = f"*-{base}"
+        try:
+            indices = es.indices.get(index=pattern).body
+        except ApiError:
+            logging.info("No indexes found for %s", base)
+            continue
+
+        # Sort indices by name (YYYY-MM-DD prefix) descending
+        index_names = sorted(indices.keys(), reverse=True)
+        if not index_names:
+            continue
+
+        # Find the live index (pointed to by the alias)
+        try:
+            alias_info = es.indices.get_alias(name=base).body
+            live_index = list(alias_info.keys())[0] if alias_info else None
+        except ApiError:
+            live_index = None
+
+        logging.info("Index %s: live version is %s", base, live_index)
+
+        if not live_index:
+            continue
+
+        # Since live is the latest, we keep it + 2 previous versions (first 3 in sorted list)
+        to_keep = index_names[:3]
+        to_delete = [idx for idx in index_names if idx not in to_keep]
+
+        for idx in to_delete:
+            logging.info("Deleting old index: %s", idx)
+            es.indices.delete(index=idx)
+
+
 def main() -> int:
     if not ES_URL:
         logging.error("ES_URL is not set")
         return 2
 
+    date_str = datetime.datetime.now().strftime("%Y-%m-%d")
     es = make_es_client()
-    ensure_index(es, ES_INDEX)
 
-    rows_iter = stream_rows_from_bq(BQ_PROJECT, BQ_DATASET, BQ_TABLE)
+    sync_results = {}  # index_base -> new_index
 
-    logging.info("Starting bulk indexing into %s …", ES_INDEX)
-    success, errors = helpers.bulk(
-        es,
-        actions_generator(rows_iter),
-        chunk_size=BULK_CHUNK_SIZE,
-        max_retries=BULK_MAX_RETRIES,
-        request_timeout=BULK_TIMEOUT,
-        raise_on_error=False,  # collect item errors
-        stats_only=False,
-    )
+    for table, cfg in TABLE_CONFIG.items():
+        base = cfg["index_base"]
+        prefix = cfg["prefix"]
+        key_field = cfg["key_field"]
 
-    if errors:
-        # errors is a list of per-item failure dicts (can be large); show first few
-        sample = errors[:5] if isinstance(errors, list) else errors
-        logging.error(
-            "Bulk completed with item errors. Sample: %s",
-            json.dumps(sample, indent=2)[:1200],
-        )
+        es_index = f"{date_str}-{base}"
 
-    logging.info("Bulk done. Successful actions: %s", success)
+        logging.info("Starting sync for %s -> %s", table, es_index)
+
+        try:
+            ensure_index(es, es_index, prefix)
+            rows_iter = stream_rows_from_bq(BQ_PROJECT, BQ_DATASET, table)
+
+            logging.info("Starting bulk indexing into %s …", es_index)
+            success, errors = helpers.bulk(
+                es,
+                actions_generator(rows_iter, es_index, prefix, key_field),
+                chunk_size=BULK_CHUNK_SIZE,
+                max_retries=BULK_MAX_RETRIES,
+                request_timeout=BULK_TIMEOUT,
+                raise_on_error=False,
+                stats_only=False,
+            )
+
+            if errors:
+                sample = errors[:5] if isinstance(errors, list) else errors
+                logging.error(
+                    "Bulk completed with item errors. Sample: %s",
+                    json.dumps(sample, indent=2)[:1200],
+                )
+
+            logging.info("Sync for %s done. Successful: %s", table, success)
+            sync_results[base] = es_index
+
+        except Exception as e:
+            logging.error("Failed to sync table %s: %s", table, e)
+            return 1
+
+    # If all successful, move aliases
+    if len(sync_results) == len(TABLE_CONFIG):
+        logging.info("All tables synced successfully. Moving aliases...")
+        actions = []
+        for base, new_index in sync_results.items():
+            # Remove existing alias from any old indexes
+            try:
+                old_indices = es.indices.get_alias(name=base).body
+                for old_idx in old_indices:
+                    actions.append({"remove": {"index": old_idx, "alias": base}})
+            except ApiError:
+                pass
+
+            # Add new alias
+            actions.append({"add": {"index": new_index, "alias": base}})
+
+        if actions:
+            es.indices.update_aliases(body={"actions": actions})
+            logging.info("Aliases updated successfully.")
+
+        # Prune old indexes
+        prune_old_indexes(es)
+
     return 0
 
 

--- a/dwh/requirements.txt
+++ b/dwh/requirements.txt
@@ -3,3 +3,4 @@ dbt-bigquery==1.9.2
 dbt-core==1.9.2
 shandy-sqlfmt[jinjafmt]
 elasticsearch
+tqdm


### PR DESCRIPTION
> [!NOTE] 
> **This PR is independent of the other ones and can be merged right away if approved.**

The script now:
1. Ingests **all** necessary tables (no need to run separately for each) to the ES index with the current date
2. If successful, move aliases
3. If successful, prune old versions of indexes: only keep the latest one + up to 2 older

Also:
* Address warning with SSL certificate checking
* Address warning with passing API parameters 
* Added tqdm progress bars
* Made logs less noisy
* Under the hood simplification, such as storing index core config in one place 
* Amended README