### PR TITLE
Add perturb_seq_reprocessed provenance flag

### DIFF
--- a/be/dataset_metadata.json
+++ b/be/dataset_metadata.json
@@ -500,6 +500,13 @@
             "es_field": "associated_datasets",
             "is_array": true,
             "description": "Filter by associated datasets"
+        },
+        {
+            "api_name": "dataset_perturb_seq_reprocessed",
+            "es_field": "perturb_seq_reprocessed",
+            "is_array": false,
+            "es_type": "boolean",
+            "description": "Filter by whether the perturb-seq dataset was re-processed from raw data"
         }
     ]
 }

--- a/be/main.py
+++ b/be/main.py
@@ -109,7 +109,12 @@ DATASET_FACET_FIELDS = [
     "sex_labels",
     "developmental_stage_labels",
     "disease_labels",
+    "perturb_seq_reprocessed",
 ]
+
+# Facet fields backed by an Elasticsearch boolean. Their aggregation buckets carry the
+# value in `key_as_string` ("true"/"false") rather than a string `key`.
+BOOLEAN_FACET_FIELDS = {"perturb_seq_reprocessed"}
 
 # Mapping from canonical (target) field names to dataset index field names
 TARGET_TO_DATASET_FIELD = {
@@ -406,6 +411,7 @@ def parse_filters_from_params(
     sex_labels: Optional[str] = None,
     developmental_stage_labels: Optional[str] = None,
     disease_labels: Optional[str] = None,
+    perturb_seq_reprocessed: Optional[str] = None,
 ) -> Optional[Dict[str, List[str]]]:
     """Parse filters from query parameters"""
     filters = {}
@@ -449,6 +455,10 @@ def parse_filters_from_params(
         ]
     if disease_labels:
         filters["disease_labels"] = [v.strip() for v in disease_labels.split(",")]
+    if perturb_seq_reprocessed:
+        filters["perturb_seq_reprocessed"] = [
+            v.strip() for v in perturb_seq_reprocessed.split(",")
+        ]
 
     return filters if filters else None
 
@@ -537,13 +547,23 @@ async def perform_search(
     for field in facet_fields:
         buckets = aggregations.get(field, {}).get("buckets", [])
         case_map = original_case.get(field, {})
-        facets_dict[field] = [
-            FacetValue(
-                value=case_map.get(bucket["key"], bucket["key"]),
-                count=bucket["doc_count"],
-            )
-            for bucket in buckets
-        ]
+        if field in BOOLEAN_FACET_FIELDS:
+            # Boolean aggregation buckets expose "true"/"false" via key_as_string.
+            facets_dict[field] = [
+                FacetValue(
+                    value=bucket.get("key_as_string", str(bucket["key"])),
+                    count=bucket["doc_count"],
+                )
+                for bucket in buckets
+            ]
+        else:
+            facets_dict[field] = [
+                FacetValue(
+                    value=case_map.get(bucket["key"], bucket["key"]),
+                    count=bucket["doc_count"],
+                )
+                for bucket in buckets
+            ]
 
     # Remap dataset field names to canonical target field names
     if is_dataset_mode:
@@ -675,6 +695,10 @@ async def search_get(
     disease_labels: Optional[str] = Query(
         None, description="Comma-separated list of disease labels (dataset mode)"
     ),
+    perturb_seq_reprocessed: Optional[str] = Query(
+        None,
+        description="Comma-separated 'true'/'false' to filter by perturb-seq re-processing (dataset mode)",
+    ),
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     size: int = Query(6, ge=1, le=100, description="Number of results per page"),
     search_after: Optional[str] = Query(
@@ -702,6 +726,7 @@ async def search_get(
         sex_labels,
         developmental_stage_labels,
         disease_labels,
+        perturb_seq_reprocessed,
     )
     parsed_search_after = None
     if search_after:

--- a/be/models.py
+++ b/be/models.py
@@ -38,6 +38,7 @@ class Facets(BaseModel):
     sex_tested: List[FacetValue]
     developmental_stages_tested: List[FacetValue]
     diseases_tested: List[FacetValue]
+    perturb_seq_reprocessed: List[FacetValue] = []
 
 
 class SearchResponse(BaseModel):

--- a/dwh/bq_dbt/models/dataset_summary.sql
+++ b/dwh/bq_dbt/models/dataset_summary.sql
@@ -184,6 +184,17 @@ with
             array_agg(distinct license_id ignore nulls) as license_ids,
             array_agg(distinct associated_datasets ignore nulls) as associated_datasets,
             any_value(score_interpretation) as score_interpretation,
+            -- Perturb-seq provenance: true if re-processed from raw data, false if
+            -- author-provided. Scoped to perturb-seq; null for other modalities until
+            -- their ingestion is updated later. The FE defaults a missing/null value to
+            -- author-provided, so every dataset still shows a provenance badge.
+            case
+                when 'Perturb-seq' in unnest(
+                    array_agg(distinct data_modality ignore nulls)
+                )
+                then coalesce(logical_or(perturb_seq_reprocessed), false)
+                else null
+            end as perturb_seq_reprocessed,
             max(ingested_at) as max_ingested_at
         from {{ ref("unified_metadata") }}
 

--- a/fe/components/search_table.py
+++ b/fe/components/search_table.py
@@ -10,6 +10,7 @@ from utils import (
     FACET_FIELDS,
     results_store,
     format_value,
+    reprocessed_badge,
 )
 
 SEARCH_RESULTS_PAGE_SIZE = 15
@@ -306,6 +307,7 @@ def render_datasets_table(results):
                 html.Th("Study Title", className="fw-semibold"),
                 html.Th("Study Year", className="fw-semibold text-center"),
                 html.Th("Data Modality", className="fw-semibold"),
+                html.Th("Provenance", className="fw-semibold"),
             ],
             style={"backgroundColor": "#f1f3f5"},
         )
@@ -342,6 +344,10 @@ def render_datasets_table(results):
         if not modality_badges:
             modality_badges = [html.Span("N/A", className="text-muted")]
 
+        provenance = reprocessed_badge(
+            record.get("perturb_seq_reprocessed"), class_name=""
+        )
+
         rows.append(
             html.Tr(
                 [
@@ -359,6 +365,7 @@ def render_datasets_table(results):
                     ),
                     html.Td(str(year), className="text-center"),
                     html.Td(html.Div(modality_badges, className="d-flex flex-wrap")),
+                    html.Td(provenance if provenance is not None else ""),
                 ]
             )
         )
@@ -413,7 +420,14 @@ def build_filter_controls(
 
     filter_type = f"{id_prefix}-facet-filter" if id_prefix else "facet-filter"
 
+    # Facet values that should be relabelled for display (value sent to the API is
+    # unchanged; only the visible label differs).
+    boolean_value_labels = {
+        "perturb_seq_reprocessed": {"true": "Yes", "false": "No"},
+    }
+
     field_icons = {
+        "perturb_seq_reprocessed": "bi-arrow-repeat",
         "license": "bi-award-fill",
         "data_modalities": "bi-database",
         "tissues_tested": "bi-universal-access-circle",
@@ -507,6 +521,7 @@ def build_filter_controls(
             continue
 
         display_name_map = {
+            "perturb_seq_reprocessed": "Reprocessed",
             "license": "License",
             "data_modalities": "Data Modalities",
             "tissues_tested": "Tissues",
@@ -545,7 +560,11 @@ def build_filter_controls(
                 continue
             if count <= 0 and value.lower() not in field_selected:
                 continue
-            options.append({"label": f"{value} ({count})", "value": value})
+            value_label_map = boolean_value_labels.get(field)
+            label_text = (
+                value_label_map.get(value.lower(), value) if value_label_map else value
+            )
+            options.append({"label": f"{label_text} ({count})", "value": value})
             option_value_map[value.lower()] = value
 
         if not options:

--- a/fe/components/target_data_table.py
+++ b/fe/components/target_data_table.py
@@ -11,7 +11,7 @@ import plotly.express as px
 from dash import html, dcc
 import dash_bootstrap_components as dbc
 
-from utils import format_number, COLORS
+from utils import format_number, COLORS, reprocessed_badge
 
 GridControlFactory = Optional[Callable[[str, Dict[str, Any]], Any]]
 
@@ -269,6 +269,16 @@ def _render_dataset_cell(
     title_elements = [
         html.Span(formatted_id, className="h4 fw-semibold text-break"),
     ]
+
+    # Perturb-seq provenance badge, shown just before the [more info] link.
+    # The modality search maps ES fields to their api_name, so this is the api_name
+    # (the /dataset and /search endpoints instead return the raw es_field).
+    provenance_badge = reprocessed_badge(
+        dataset_meta.get("dataset_perturb_seq_reprocessed"),
+        class_name="ms-2 align-self-center",
+    )
+    if provenance_badge is not None:
+        title_elements.append(provenance_badge)
 
     if url_dataset_id:
         title_elements.append(

--- a/fe/pages/dataset.py
+++ b/fe/pages/dataset.py
@@ -13,7 +13,13 @@ from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 
 from components.target_data_table import crispr_table, mave_heatmap, perturb_seq_table
-from utils import BACKEND_URL, COLORS, fetch_dataset, fetch_dataset_rows
+from utils import (
+    BACKEND_URL,
+    COLORS,
+    fetch_dataset,
+    fetch_dataset_rows,
+    reprocessed_badge,
+)
 
 
 dash.register_page(
@@ -155,7 +161,7 @@ def _create_associated_datasets_display(associated_datasets: Any) -> html.Div:
     """Create display for associated datasets field."""
     if not associated_datasets:
         return _create_field_display("associated_datasets", None)
-    
+
     # Parse JSON strings if needed
     items = []
     if isinstance(associated_datasets, list):
@@ -171,17 +177,17 @@ def _create_associated_datasets_display(associated_datasets: Any) -> html.Div:
                     continue
             elif isinstance(item, dict):
                 items.append(item)
-    
+
     if not items:
         return _create_field_display("associated_datasets", None)
-    
+
     # Create display for each item
     display_items = []
     for item in items:
         description = item.get("dataset_description", "N/A")
         file_name = item.get("dataset_file_name", "")
         uri = item.get("dataset_uri", "")
-        
+
         if uri and file_name:
             link = html.A(
                 file_name,
@@ -210,7 +216,7 @@ def _create_associated_datasets_display(associated_datasets: Any) -> html.Div:
                     className="mb-2",
                 )
             )
-    
+
     return html.Div(
         [
             html.Dt(
@@ -417,7 +423,13 @@ def render_dataset(data: Optional[Dict[str, Any]]):
         "data_modalities",
     ]
     PRIMARY_GROUPED = {"perturbation_type"}
-    SKIP_STANDALONE = {"dataset_id", "max_ingested_at", "study_uri"}
+    SKIP_STANDALONE = {
+        "dataset_id",
+        "max_ingested_at",
+        "study_uri",
+        # Rendered as a badge next to the title instead of in the field list.
+        "perturb_seq_reprocessed",
+    }
 
     study_uri = standalone_fields.get("study_uri")
 
@@ -668,7 +680,10 @@ def render_dataset(data: Optional[Dict[str, Any]]):
                         [
                             html.I(
                                 className="bi bi-info-circle-fill me-2",
-                                style={"fontSize": "1.1rem", "color": COLORS["primary"]},
+                                style={
+                                    "fontSize": "1.1rem",
+                                    "color": COLORS["primary"],
+                                },
                             ),
                             html.Strong("Score Interpretation: ", className="me-1"),
                             html.Span(score_interpretation),
@@ -727,10 +742,19 @@ def render_dataset(data: Optional[Dict[str, Any]]):
             "crispr_perturbation_gene_search": "",
         }
 
-    header_section = html.H1(
-        f"Dataset: {formatted_dataset_id}",
-        className="display-5 fw-bold mb-4 text-center",
-        style={"color": COLORS["primary"]},
+    provenance_badge = reprocessed_badge(dataset_data.get("perturb_seq_reprocessed"))
+    title_children = [
+        html.H1(
+            f"Dataset: {formatted_dataset_id}",
+            className="display-5 fw-bold mb-0",
+            style={"color": COLORS["primary"]},
+        )
+    ]
+    if provenance_badge is not None:
+        title_children.append(provenance_badge)
+    header_section = html.Div(
+        title_children,
+        className="d-flex align-items-center justify-content-center gap-2 mb-4 flex-wrap",
     )
 
     # Hidden inputs for no-modality case (needed for callback)
@@ -759,17 +783,21 @@ def render_dataset(data: Optional[Dict[str, Any]]):
         [
             header_section,
             metadata_section,
-            data_section if modality else html.Div(
-                [
-                    html.Hr(className="my-4"),
-                    # Include hidden inputs when no modality
-                    hidden_search_inputs,
-                    html.Div(
-                        "No data visualization available for this dataset.",
-                        className="text-muted text-center py-4",
-                    ),
-                ],
-                style={"maxWidth": "900px", "margin": "0 auto"},
+            (
+                data_section
+                if modality
+                else html.Div(
+                    [
+                        html.Hr(className="my-4"),
+                        # Include hidden inputs when no modality
+                        hidden_search_inputs,
+                        html.Div(
+                            "No data visualization available for this dataset.",
+                            className="text-muted text-center py-4",
+                        ),
+                    ],
+                    style={"maxWidth": "900px", "margin": "0 auto"},
+                )
             ),
         ]
     )
@@ -1040,7 +1068,10 @@ def render_dataset_data(
     needs_fetch = store_data.get("needs_fetch", False)
 
     # Handle pagination
-    if isinstance(triggered_id, dict) and triggered_id.get("type") == "dataset-paginate":
+    if (
+        isinstance(triggered_id, dict)
+        and triggered_id.get("type") == "dataset-paginate"
+    ):
         direction = triggered_id.get("direction")
         if direction:
             store_data = _paginate_data(store_data, direction)
@@ -1054,8 +1085,10 @@ def render_dataset_data(
         new_effect_search = effect_gene_search or ""
 
         # Check if search terms changed
-        if (new_perturbation_search != old_perturbation_search or
-                new_effect_search != old_effect_search):
+        if (
+            new_perturbation_search != old_perturbation_search
+            or new_effect_search != old_effect_search
+        ):
             store_data["perturbation_gene_search"] = new_perturbation_search
             store_data["effect_gene_search"] = new_effect_search
             # Reset pagination when search changes
@@ -1133,6 +1166,7 @@ def download_dataset_data(n_clicks, store_data):
 
     try:
         import requests
+
         response = requests.get(download_url, params=params, timeout=60)
         response.raise_for_status()
         content = response.text

--- a/fe/pages/datasets.py
+++ b/fe/pages/datasets.py
@@ -6,7 +6,7 @@ import dash_bootstrap_components as dbc
 from urllib.parse import parse_qs
 from utils import (
     COLORS,
-    FACET_FIELDS,
+    DATASET_FACET_FIELDS,
     fetch_search_results,
     fetch_all_search_results,
 )
@@ -417,7 +417,11 @@ def _render_server_side(
 
     if not results and total == 0:
         filters_children = build_filter_controls(
-            facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+            facets,
+            selected_filters,
+            DATASET_FACET_FIELDS,
+            "datasets",
+            id_prefix="datasets",
         )
         return (
             dbc.Alert(
@@ -441,7 +445,7 @@ def _render_server_side(
 
     table = render_datasets_table(results)
     filters_children = build_filter_controls(
-        facets, selected_filters, FACET_FIELDS, "datasets", id_prefix="datasets"
+        facets, selected_filters, DATASET_FACET_FIELDS, "datasets", id_prefix="datasets"
     )
 
     pagination_style = {"display": "flex"} if total_pages > 1 else {"display": "none"}
@@ -499,6 +503,7 @@ def download_datasets_metadata(n_clicks, store_data, selected_values, filter_ids
         "study_title",
         "study_year",
         "data_modalities",
+        "perturb_seq_reprocessed",
     ]
 
     csv_lines = [",".join(columns)]

--- a/fe/utils.py
+++ b/fe/utils.py
@@ -28,6 +28,20 @@ FACET_FIELDS = [
     "diseases_tested",
 ]
 
+# Facet fields for the datasets browse page. The backend remaps dataset facets to these
+# canonical names; perturb_seq_reprocessed is a dataset-only facet kept under its own name.
+DATASET_FACET_FIELDS = [
+    "perturb_seq_reprocessed",
+    "license",
+    "data_modalities",
+    "tissues_tested",
+    "cell_types_tested",
+    "cell_lines_tested",
+    "sex_tested",
+    "developmental_stages_tested",
+    "diseases_tested",
+]
+
 # Designer color scheme
 COLORS = {
     "primary": "#007B53",
@@ -44,6 +58,34 @@ DATA_MODALITIES_COLOURS = {
     "CRISPR screen": COLORS["secondary"],
     "MAVE": COLORS["red"],
 }
+
+
+def reprocessed_badge(value: Any, class_name: str = "ms-2"):
+    """Provenance badge for a dataset.
+
+    ``value`` is a dataset's ``perturb_seq_reprocessed`` field. ``True`` (or the
+    string ``"true"``) -> re-processed from raw data. Anything else -- ``False``,
+    ``None``, or a missing field -- defaults to author-provided, so every dataset
+    shows a badge regardless of modality.
+    """
+    is_reprocessed = value is True or (
+        isinstance(value, str) and value.strip().lower() == "true"
+    )
+    if is_reprocessed:
+        return dbc.Badge(
+            [html.I(className="bi bi-stars me-1"), "Reprocessed"],
+            color="success",
+            pill=True,
+            className=class_name,
+        )
+    return dbc.Badge(
+        [html.I(className="bi bi-file-earmark-text me-1"), "Author-provided"],
+        color="light",
+        pill=True,
+        className=class_name,
+        style={"border": "1px solid #ced4da", "color": COLORS["gray"]},
+    )
+
 
 SUMMARY_CACHE_TTL = 60  # seconds
 


### PR DESCRIPTION
Surface whether a dataset was re-processed from raw data or author-provided, across the datasets browse page, dataset detail page, and target detail page.

- dbt: add perturb_seq_reprocessed to dataset_summary (scoped to perturb-seq, null for other modalities until their ingestion is updated)
- be: register the field in dataset_metadata.json (drives the ES boolean mapping, filterability, and returned source); add it as a dataset facet with boolean-aware extraction and filtering; add it to the Facets model
- fe: shared provenance badge (Reprocessed / Author-provided, defaulting a missing value to author-provided); provenance column and Reprocessed facet on the datasets page; badge on the dataset and target detail pages